### PR TITLE
web: code editor styles, remove 800 and 900 weight

### DIFF
--- a/web/pages/docs/quickstart.md
+++ b/web/pages/docs/quickstart.md
@@ -16,7 +16,7 @@ If you want to use our CSS, you'll also need to include the Google Font it uses:
 
 ```html
 <link href="https://treehouse.sh/app/main.css" rel="stylesheet" />
-<link href="https://fonts.googleapis.com/css2?family=Rubik:wght@300;400&display=swap" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=Figtree:ital,wght@0,400;0,600;0,700;0,400&display=swap" rel="stylesheet" />
 ```
 
 Then you just need some JavaScript to import and call setup with a built-in or custom backend adapter:

--- a/web/static/style/design.css
+++ b/web/static/style/design.css
@@ -60,12 +60,8 @@
 
   --weight-light: 300;
   --weight-regular: 400;
- /* let's not use medium
-  --weight-medium: 500;*/
   --weight-semibold: 600;
   --weight-bold: 700;
-  --weight-extrabold: 800;
-  --weight-black: 900;
 
   --layer-1: 10;
   --layer-2: 20;
@@ -82,7 +78,7 @@
 
 .h1,h1,.h2,h2,.h3,h3,.h4,h4,.h5,h5 {
   line-height: 1.1;
-  font-weight: var(--weight-extrabold);
+  font-weight: var(--weight-bold);
 }
 .h2,h2,.h3,h3,.h4,h4,.h5,h5 {
   font-weight: var(--weight-bold);

--- a/web/static/style/site.css
+++ b/web/static/style/site.css
@@ -199,26 +199,42 @@ input[type="text"] {
   background-color: var(--primary);
 }
 
+code:not(pre > code), pre > code > div {
+  background-color: var(--gray-900);
+  color: var(--white);
+  font-size: smaller;
+  line-height: var(--6);
+  border-radius: 4px;
+  padding: var(--2);
+}
+
 pre > code > div {
   display: flex;
-  font-size: smaller;
   overflow-x: auto;
-  padding-bottom: var(--2);
-  padding-top: var(--2);
-  box-shadow: inset -4px 0px 6px -4px #ccc;
 }
 
-code:not(pre > code) {
-  background-color: var(--gray-800);
-  color: var(--white);
-  border-radius: 4px;
-  padding-left: var(--1);
-  padding-right: var(--1);
-  padding-top: var(--1);
-  padding-bottom: var(--1);
+/*code editor color theme (temporarily borrowed from nite owl)*/
+.shj-numbers, .shj-syn-cmnt {
+  color: var(--gray-100);
 }
-
-
+.shj-syn-insert, .shj-syn-str {
+  color: #AEDB67;
+}
+.shj-syn-deleted, .shj-syn-var {
+  color: #55A3E2;
+}
+.shj-syn-oper {
+  color: #ED524D;
+}
+.shj-syn-class {
+  color: #C792EA;
+}
+.shj-syn-kwd {
+  color: #80DBCA;
+}
+.shj-syn-section, .shj-syn-func {
+  color: #FEEB95
+}
 
 /* Responsive */
 


### PR DESCRIPTION
* update code editor styles (padding and colors)
* change all headers to 700 weight (after looking at them for awhile they started to feel too heavy)

(at some point i will make a dark mode color palette for the code editor, but i could spend days on that so for now i'm borrowing colors from the VS code Nite Owl theme)