### PR TITLE
app: fix title node styling issue

### DIFF
--- a/web/static/app/main.css
+++ b/web/static/app/main.css
@@ -109,12 +109,6 @@ main {
   padding: 0 var(--padding);
 }
 
-.panel > .body > .title-node {
-/* todo: set CSS variables for app header styles */
-  font-size: var(--6);
-  font-weight: var(--weight-bold);
-}
-
 
 /*------------NODES------------*/
 /*keep max line length from getting too long for readibility*/
@@ -136,6 +130,11 @@ main {
   display: block;
   line-height: var(--body-line-height);
   border: none;
+}
+.title-node textarea {
+  line-height: 0.95;
+  font-size: var(--6);
+  font-weight: var(--weight-bold);
 }
 .new-node svg {
   flex-shrink: 0;

--- a/web/static/app/main.css
+++ b/web/static/app/main.css
@@ -131,8 +131,7 @@ main {
   line-height: var(--body-line-height);
   border: none;
 }
-.title-node textarea {
-  line-height: 0.95;
+.title-node textarea, .title-node > .node-container > span {
   font-size: var(--6);
   font-weight: var(--weight-bold);
 }


### PR DESCRIPTION
closes #99 
i think. there's a hack in there (line height 0.95) to make the descenders (g, p, etc.) not get cut off at the bottom. i can't figure out a better way to do it. but it gets the job done in the meantime.