### PR TITLE
tiny hack to fix vertical label alignment

### DIFF
--- a/web/static/app/main.css
+++ b/web/static/app/main.css
@@ -94,7 +94,15 @@ main {
   align-items: center;
 }
 .topbar-item > div {
-  line-height: 0.1;
+  margin-bottom: -1px;
+}
+/*fun hack to get the top navbar items vertically aligned
+with their icon for Safari only*/
+@supports (-webkit-hyphens:none)
+{
+  .topbar-item > div {
+    margin-bottom: -3px;
+  }
 }
 
 /*------------PANELS------------*/
@@ -371,6 +379,7 @@ svg.node-bullet circle#node-collapsed {
 }
 
 
+
 /*------------MOBILE------------*/
 
 @media (max-width: 600px) {
@@ -394,8 +403,6 @@ the top nav in a more elegant way at some point*/
 
   }
 }
-
-
 
 
 


### PR DESCRIPTION
fixes #87 

focused on aligning the text w/ the search text, setting a negative margin seems like the only way to fix it. and yes chrome is literally a 1px difference but i can tell 😆

<img width="800" alt="image" src="https://github.com/treehousedev/treehouse/assets/1813419/4a816201-11b1-4436-903e-a7bf1af7d66a">
