### PR TITLE
Centralize node icon colors in CSS

### DIFF
--- a/lib/ui/outline.tsx
+++ b/lib/ui/outline.tsx
@@ -165,9 +165,9 @@ export const OutlineNode: m.Component<Attrs, State> = {
             {(objectHas(node, "handleIcon"))
               ? objectCall(node, "handleIcon")
               : <svg class="node-bullet" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-                {(subCount(node) > 0 && !expanded)?<circle cx="8" cy="7" r="7" fill="lightgray" />:null}
-                <circle cx="8" cy="7" r="3"/>,
-                {(isRef)?<circle cx="8" cy="7" r="7" fill="none" stroke="gray" stroke-width="1" stroke-dasharray="3,3" />:null}
+                {(subCount(node) > 0 && !expanded)?<circle id="node-collapsed-handle" cx="8" cy="7" r="7" />:null}
+                <circle cx="8" cy="7" r="3" fill="currentColor" />,
+                {(isRef)?<circle id="node-reference-handle" cx="8" cy="7" r="7" fill="none" stroke-width="1" stroke="currentColor" stroke-dasharray="3,3" />:null}
               </svg>
             }
           </div>

--- a/web/static/app/main.css
+++ b/web/static/app/main.css
@@ -167,12 +167,10 @@ with their icon for Safari only*/
   height: 1rem;
   margin-right: 0.5rem;
   padding-left: 1px;
+  color: var(--node-icon-color);
 }
 .new-node svg circle {
-  fill: var(--gray-200);
-}
-.new-node svg path {
-  fill: var(--gray-600);
+  fill: var(--node-icon-accent-color);
 }
 .new-node input {
   border: 0px;
@@ -185,10 +183,9 @@ with their icon for Safari only*/
 .expanded-node > .indent {
   width: var(--8);
 }
-/*todo: make common class for shared icon button styles*/
 svg.node-menu {
   cursor: pointer;
-  fill: var(--gray-600);
+  fill: var(--node-icon-color);
   width: 1rem;
   height: 1rem;
   margin-left: -1rem;
@@ -202,12 +199,10 @@ svg.node-menu {
   margin-right: var(--2);
   padding-left: 1px;
   margin-top: var(--1);
+  color: var(--node-icon-color);
 }
-svg.node-bullet {
-  fill: var(--gray-600);
-}
-svg.node-bullet circle#node-collapsed {
-  fill: var(--gray-200);
+svg.node-bullet circle#node-collapsed-handle {
+  fill: var(--node-icon-accent-color);
 }
 
 /*------------TABLE VIEW------------*/

--- a/web/static/style/design.css
+++ b/web/static/style/design.css
@@ -83,6 +83,9 @@
   --body-line-height: 1.5;
   --text-small: 0.875rem;
 
+  --node-icon-color: var(--gray-600);
+  --node-icon-accent-color: var(--gray-200);
+
 }
 
 .h1,h1,.h2,h2,.h3,h3,.h4,h4,.h5,h5 {


### PR DESCRIPTION
* make sure all of the node handle icons are the same color + accent color (created variables)
* centralize those styles by replacing inline colors with "currentColor" so .node-handle can define all of them