### PR TITLE
Remove line height because it doesn't do anything

### DIFF
--- a/web/static/app/main.css
+++ b/web/static/app/main.css
@@ -80,7 +80,6 @@ main {
 /*------------TOPBAR------------*/
 .topbar {
   padding: var(--padding) calc(var(--padding)*2);
-  line-height: 1;
   font-size: var(--text-small);
   font-weight: var(--weight-semibold);
   border-bottom: 1px solid var(--border-color-light);


### PR DESCRIPTION
causes a misalignment issue in the topbar when setting a different font (sublime custom theme, default monospace font), and it doesn't seem to be doing anything anyway so i removed it.