### PR TITLE
ui: hide node handle when name is empty

### DIFF
--- a/lib/ui/outline.tsx
+++ b/lib/ui/outline.tsx
@@ -161,7 +161,7 @@ export const OutlineNode: m.Component<Attrs, State> = {
               viewBox="0 0 16 16">
             {state.hover && <path style={{transform: "translateY(-1px)"}} fill-rule="evenodd" d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z" />}
           </svg>
-          <div class="node-handle shrink-0" onclick={toggle} ondblclick={open} oncontextmenu={(e) => workbench.showMenu(e, {node: handleNode, path})} data-menu="node">
+          <div class="node-handle shrink-0" onclick={toggle} ondblclick={open} oncontextmenu={(e) => workbench.showMenu(e, {node: handleNode, path})} data-menu="node" style={{ display: node.name ? 'block' : 'none' }}>
             {(objectHas(node, "handleIcon"))
               ? objectCall(node, "handleIcon")
               : <svg class="node-bullet" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
This is for #31 

This toggles between display: none or block depending on if `node.name` is empty or not. There might be a better way to do this. Maybe using a nbsp or a blank icon (with a little width) instead of hiding the entire handle would make sense.

I considered trying to do something conditional in `handleIcon` on TextField, but it doesn't look like the component holds the node data itself so it didn't seem like it would work.