### PR TITLE
ui: added some placeholder handling and changed search node ui

### DIFF
--- a/lib/com/search.tsx
+++ b/lib/com/search.tsx
@@ -29,8 +29,12 @@ export class SearchNode {
     return <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
   }
 
+  handlePlaceholder(): any {
+    return 'Enter search value';
+  }
+
   displayName(node: Node): any {
-    return `Search for "${node.name}"`;
+    return node.name;
   }
 
   onAttach(node: Node) {

--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -75,6 +75,7 @@ export async function setup(document: Document, target: HTMLElement, backend: Ba
       const search = new SearchNode();
       ctx.node.addComponent(search);
       workbench.workspace.setExpanded(ctx.path.head, ctx.node, true);
+      workbench.focus(ctx.path);
     }
   });
 

--- a/lib/ui/node/editor.tsx
+++ b/lib/ui/node/editor.tsx
@@ -1,7 +1,7 @@
 import { objectCall, objectHas } from "../../model/hooks.ts";
 
 export const NodeEditor: m.Component = {
-  view ({attrs: {workbench, path, onkeydown, disallowEmpty, editValue}, state}) {
+  view ({attrs: {workbench, path, onkeydown, disallowEmpty, editValue, placeholder}, state}) {
     const node = path.node;
     let prop = (editValue) ? "value" : "name";
     
@@ -32,7 +32,6 @@ export const NodeEditor: m.Component = {
       }
     }
 
-    let placeholder;
     if (node.raw.Rel === "Fields") {
       placeholder = (editValue) ? "Value" : "Field";
     }

--- a/lib/ui/outline.tsx
+++ b/lib/ui/outline.tsx
@@ -38,7 +38,8 @@ export const OutlineNode: m.Component<Attrs, State> = {
       node = handleNode.refTo;
     }
 
-    const expanded = workbench.workspace.getExpanded(path.head, handleNode); 
+    const expanded = workbench.workspace.getExpanded(path.head, handleNode);
+    const placeholder = objectHas(node, "handlePlaceholder") ? objectCall(node, "handlePlaceholder") : '';
 
     const hover = (e) => {
       state.hover = true;
@@ -155,7 +156,8 @@ export const OutlineNode: m.Component<Attrs, State> = {
       if (node.id === workbench.context?.node?.id || state.hover) {
         return true;
       }
-      return node.name.length > 0;
+      if (node.name.length > 0) return true;
+      if (placeholder.length > 0) return true;
     }
 
     return (
@@ -187,7 +189,7 @@ export const OutlineNode: m.Component<Attrs, State> = {
               </div>
             : <div class="flex grow items-start flex-row">
                 {objectHas(node, "beforeEditor") && m(objectCall(node, "beforeEditor"), {node})}
-                <NodeEditor workbench={workbench} path={path} onkeydown={checkCommands} />
+                <NodeEditor workbench={workbench} path={path} onkeydown={checkCommands} placeholder={placeholder} />
                 {objectHas(node, "afterEditor") && m(objectCall(node, "afterEditor"), {node})}
               </div>
           }


### PR DESCRIPTION
Closes #134 

This makes the changes suggested in the issue. I added a `handlePlaceholder` method to `SearchNode`, leaving the possibility for any Node type to do something with its placeholder text. The way I'm calling it in lib/ui/outline.tsx isn't consistent with the way it's called in the rest of the component, but I wasn't sure of the best way to have `placeholder` be available for the check on L160. That check (to decide whether to show the handle or not) was added because it looked weird when the placeholder was showing, but the handle wasn't.

I feel like there might be a better way of doing this so let me know what you think.