### PR TITLE
Managed

### DIFF
--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -146,6 +146,7 @@ export async function setup(document: Document, target: HTMLElement, backend: Ba
       if (!ctx.node) return;
       if (ctx.node.childCount > 0) return;
       if (ctx.node.componentCount > 0) return;
+      if (ctx.path.previous && objectManaged(ctx.path.previous)) return;
       const path = ctx.path.clone();
       path.pop(); // drop node
       const field = workbench.workspace.new(ctx.node.name, "");
@@ -212,8 +213,9 @@ export async function setup(document: Document, target: HTMLElement, backend: Ba
       const node = ctx.node; // redraw seems to unset ctx.node
       const path = ctx.path.clone();
       let prev = node.prevSibling;
-      if (prev && objectManaged(prev)) {
+      while (prev && objectManaged(prev)) {
         prev = prev.prevSibling;
+        if (!prev) return;
       }
       if (prev !== null) {
         path.pop(); // drop node
@@ -233,6 +235,7 @@ export async function setup(document: Document, target: HTMLElement, backend: Ba
     action: (ctx: Context) => {
       if (!ctx.node) return;
       if (ctx.node.raw.Rel === "Fields") return;
+      if (ctx.path.previous && objectManaged(ctx.path.previous)) return;
       const node = ctx.node; // redraw seems to unset ctx.node
       const parent = ctx.path.previous;
       const path = ctx.path.clone();
@@ -268,7 +271,7 @@ export async function setup(document: Document, target: HTMLElement, backend: Ba
           p.pop(); // drop node
           p.pop(); // drop parent
           let parentSib = parent.prevSibling;
-          if (objectManaged(parentSib)) {
+          while (parentSib && objectManaged(parentSib)) {
             parentSib = parentSib.prevSibling;
             if (!parentSib) return;
           }
@@ -308,7 +311,7 @@ export async function setup(document: Document, target: HTMLElement, backend: Ba
           p.pop(); // drop node
           p.pop(); // drop parent
           let parentSib = parent.nextSibling;
-          if (objectManaged(parentSib)) {
+          while (parentSib && objectManaged(parentSib)) {
             parentSib = parentSib.nextSibling;
             if (!parentSib) return;
           }
@@ -351,6 +354,7 @@ export async function setup(document: Document, target: HTMLElement, backend: Ba
     title: "Insert Before",
     action: (ctx: Context) => {
       if (!ctx.node) return;
+      if (ctx.path.previous && objectManaged(ctx.path.previous)) return;
       const node = workbench.workspace.new("");
       node.parent = ctx.node.parent;
       node.siblingIndex = ctx.node.siblingIndex;
@@ -365,6 +369,7 @@ export async function setup(document: Document, target: HTMLElement, backend: Ba
     title: "Insert Node",
     action: (ctx: Context, name: string = "") => {
       if (!ctx.node) return;
+      if (ctx.path.previous && objectManaged(ctx.path.previous)) return;
       const node = workbench.workspace.new(name);
       node.parent = ctx.node.parent;
       node.siblingIndex = ctx.node.siblingIndex + 1;
@@ -381,6 +386,7 @@ export async function setup(document: Document, target: HTMLElement, backend: Ba
     action: (ctx: Context) => {
       // TODO: prevent creating reference to reference
       if (!ctx.node) return;
+      if (ctx.path.previous && objectManaged(ctx.path.previous)) return;
       const node = workbench.workspace.new("");
       node.parent = ctx.node.parent;
       node.siblingIndex = ctx.node.siblingIndex + 1;
@@ -397,6 +403,7 @@ export async function setup(document: Document, target: HTMLElement, backend: Ba
     action: (ctx: Context) => {
       if (!ctx.node) return;
       if (ctx.node.id.startsWith("@")) return;
+      if (ctx.path.previous && objectManaged(ctx.path.previous)) return; // should probably provide feedback or disable delete
       const above = workbench.workspace.findAbove(ctx.path);
       ctx.node.destroy();
       m.redraw.sync();

--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -24,6 +24,7 @@ import { Checkbox } from "./com/checkbox.tsx";
 import { Page } from "./com/page.tsx";
 import { TextField } from "./com/textfield.tsx";
 import { Clock } from "./com/clock.tsx";
+import { objectManaged } from "./model/hooks.ts";
 
 export { BrowserBackend, SearchIndex_MiniSearch } from "./backend/browser.ts";
 export { GitHubBackend } from "./backend/github.ts";
@@ -210,7 +211,10 @@ export async function setup(document: Document, target: HTMLElement, backend: Ba
       if (ctx.node.raw.Rel === "Fields") return;
       const node = ctx.node; // redraw seems to unset ctx.node
       const path = ctx.path.clone();
-      const prev = node.prevSibling;
+      let prev = node.prevSibling;
+      if (prev && objectManaged(prev)) {
+        prev = prev.prevSibling;
+      }
       if (prev !== null) {
         path.pop(); // drop node
         path.push(prev);
@@ -263,7 +267,11 @@ export async function setup(document: Document, target: HTMLElement, backend: Ba
           const p = ctx.path.clone();
           p.pop(); // drop node
           p.pop(); // drop parent
-          const parentSib = parent.prevSibling;
+          let parentSib = parent.prevSibling;
+          if (objectManaged(parentSib)) {
+            parentSib = parentSib.prevSibling;
+            if (!parentSib) return;
+          }
           p.push(parentSib);
           p.push(node);
           node.parent = parentSib;
@@ -299,7 +307,11 @@ export async function setup(document: Document, target: HTMLElement, backend: Ba
           const p = ctx.path.clone();
           p.pop(); // drop node
           p.pop(); // drop parent
-          const parentSib = parent.nextSibling;
+          let parentSib = parent.nextSibling;
+          if (objectManaged(parentSib)) {
+            parentSib = parentSib.nextSibling;
+            if (!parentSib) return;
+          }
           p.push(parentSib);
           p.push(node);
           node.parent = parentSib;
@@ -323,6 +335,7 @@ export async function setup(document: Document, target: HTMLElement, backend: Ba
     title: "Insert Child",
     action: (ctx: Context, name: string = "", siblingIndex?: number) => {
       if (!ctx.node) return;
+      if (objectManaged(ctx.node)) return;
       const node = workbench.workspace.new(name);
       node.parent = ctx.node;
       if (siblingIndex !== undefined) {

--- a/lib/model/hooks.ts
+++ b/lib/model/hooks.ts
@@ -41,3 +41,10 @@ export function objectCall(obj: Node, hook: string, ...args: any[]): any {
     }
   }
 }
+
+// shorthand for nodes that have child provider hook.
+// use this to determine if some commands should be
+// prevented since visible children will not be impacted.
+export function objectManaged(obj: Node): boolean {
+  return objectHas(obj, "objectChildren");
+}


### PR DESCRIPTION
Closes #105 focusing on making commands skip/ignore when working with a "managed" node (only search node for now). Repeating commit message since it includes command behaviors changed for QA:

- create-field is ignored when path parent is managed
- indent skips managed node and uses previous/above sibling or cancels
- outdent is ignored when path parent is managed
- move-up skips managed node and uses previous/above sibling or cancels
- move-down skips managed node and uses next/below sibling or cancels
- insert-child (inc newline at end of open parent) is ignored when node is managed
- insert and insert-before is ignored when path parent is managed
- create-reference is ignored when path parent is managed

@taramk 