### PR TITLE
lib: update search node icon handler to show collapsed state

### DIFF
--- a/lib/com/search.tsx
+++ b/lib/com/search.tsx
@@ -25,8 +25,16 @@ export class SearchNode {
     this.searchDebounce = debounce(this.search.bind(this));
   }
 
-  handleIcon(): any {
-    return <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
+  handleIcon(collapsed: boolean = false): any {
+    return (
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="node-bullet" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        {collapsed?<circle id="node-collapsed-handle" stroke="none" cx="12" cy="12" r="12"/>:null}
+        <svg xmlns="http://www.w3.org/2000/svg" x="5" y="5" width="14" height="14" viewBox="0 0 24 24">
+          <circle cx="11" cy="11" r="8"></circle>
+          <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+        </svg>
+      </svg>
+    );
   }
 
   handlePlaceholder(): any {

--- a/lib/ui/outline.tsx
+++ b/lib/ui/outline.tsx
@@ -175,7 +175,7 @@ export const OutlineNode: m.Component<Attrs, State> = {
           </svg>
           <div class="node-handle shrink-0" onclick={toggle} ondblclick={open} oncontextmenu={(e) => workbench.showMenu(e, {node: handleNode, path})} data-menu="node" style={{ display: showHandle() ? 'block' : 'none' }}>
             {(objectHas(node, "handleIcon"))
-              ? objectCall(node, "handleIcon")
+              ? objectCall(node, "handleIcon", subCount(node) > 0 && !expanded)
               : <svg class="node-bullet" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
                 {(subCount(node) > 0 && !expanded)?<circle id="node-collapsed-handle" cx="8" cy="7" r="7" />:null}
                 <circle cx="8" cy="7" r="3" fill="currentColor" />,


### PR DESCRIPTION
This adds a `collapsed` arg to `handleIcon` so the background indicator can be shown. So far, these kinds of decisions were made in the outline component, so let me know if you're ok with this change.

Also, I ended up doing a nested svg just so I can easily control the size/position of the inner search icon.

By the way, I considered adding the `subCount(node) > 0 && !expanded` logic to its own function, but it felt awkward when I did. But let me know if you would rather it not be repeated twice.

Closes #150 