### PR TITLE
dialogs

### DIFF
--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -26,8 +26,6 @@ import { TextField } from "./com/textfield.tsx";
 import { Clock } from "./com/clock.tsx";
 import { objectManaged } from "./model/hooks.ts";
 
-import { LockStolenMessage } from "./ui/notices.tsx";
-
 export { BrowserBackend, SearchIndex_MiniSearch } from "./backend/browser.ts";
 export { GitHubBackend } from "./backend/github.ts";
 
@@ -512,18 +510,7 @@ export async function setup(document: Document, target: HTMLElement, backend: Ba
       });
     }
   });
-  workbench.commands.registerCommand({
-    id: "toggle-dialog",
-    title: "Toggle Dialog",
-    action: (ctx: Context) => {
-      if (workbench.isDialogOpen()) {
-        workbench.closeDialog();
-      } else {
-        workbench.showDialog(m(LockStolenMessage, {workbench, finished: () => workbench.hideDialog()}), false);
-      }
-      
-    }
-  });
+
 
 
   workbench.menus.registerMenu("node", [

--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -26,6 +26,8 @@ import { TextField } from "./com/textfield.tsx";
 import { Clock } from "./com/clock.tsx";
 import { objectManaged } from "./model/hooks.ts";
 
+import { LockStolenMessage } from "./ui/notices.tsx";
+
 export { BrowserBackend, SearchIndex_MiniSearch } from "./backend/browser.ts";
 export { GitHubBackend } from "./backend/github.ts";
 
@@ -510,6 +512,18 @@ export async function setup(document: Document, target: HTMLElement, backend: Ba
       });
     }
   });
+  workbench.commands.registerCommand({
+    id: "toggle-dialog",
+    title: "Toggle Dialog",
+    action: (ctx: Context) => {
+      if (workbench.isDialogOpen()) {
+        workbench.closeDialog();
+      } else {
+        workbench.showDialog(m(LockStolenMessage, {workbench, finished: () => workbench.hideDialog()}), false);
+      }
+      
+    }
+  });
 
 
   workbench.menus.registerMenu("node", [
@@ -559,13 +573,6 @@ export async function setup(document: Document, target: HTMLElement, backend: Ba
       e.stopPropagation();
       e.preventDefault();
       return;
-    }
-
-    // TODO: find a better way to do this?
-    if (e.key === "Escape") {
-      if (workbench.curtain && workbench.curtain.onclick) {
-        workbench.curtain.onclick(e);
-      }
     }
   });
 

--- a/lib/ui/app.tsx
+++ b/lib/ui/app.tsx
@@ -58,6 +58,7 @@ export const App: m.Component = {
           </div>
         </div>
         
+        {/* curtain is only used by search, but it will soon be ported to a dialog and we can remove this */}
         {workbench.curtain && 
           <div onclick={workbench.curtain.onclick} style={{
             zIndex: "10",
@@ -67,10 +68,24 @@ export const App: m.Component = {
             width: "100%",
             height: "100%"
           }}></div>}
-        {workbench.menu && <Menu workbench={workbench} {...workbench.menu} />}
-        {workbench.palette && <CommandPalette workbench={workbench} {...workbench.palette} />}
-        {workbench.quickadd && <QuickAdd workbench={workbench} />}
-        {workbench.notice && <Notice workbench={workbench} {...workbench.notice} />}
+        
+        <dialog 
+          class={(workbench.dialog.backdrop) ? "backdrop" : ""} 
+          style={(workbench.dialog.pos) ? {margin: "0", ...workbench.dialog.pos} : {top: "-50%"}}
+          onclick={e => {
+            const dialog = e.target.closest("dialog");
+            const dim = dialog.getBoundingClientRect();
+            if (
+              e.clientX < dim.left ||
+              e.clientX > dim.right ||
+              e.clientY < dim.top ||
+              e.clientY > dim.bottom
+            ) {
+              dialog.close();
+            }
+          }}>
+            {workbench.dialog.body()}
+        </dialog>
       </main>
     )
   }

--- a/lib/ui/menu.tsx
+++ b/lib/ui/menu.tsx
@@ -13,19 +13,13 @@ export const Menu: m.Component = {
       if (cmd) {
         workbench.executeCommand(cmd.id, ctx);
       }
-      workbench.hideMenu();
+      workbench.closeDialog();
     };
-    let posStyle = {left: `${x}px`};
-    if (align === "right") {
-      posStyle = {right: `${x}px`};
-    }
     return (
-<ul class="menu" style={Object.assign(posStyle, {
+<ul class="menu" style={{
   margin: "0",
-  position: "absolute",
-  top: `${y}px`,
-  display: "inline-block",
-})}>
+  display: "inline-block"
+}}>
   {items.filter(i => !i.when || i.when()).map(i => {
     let title = "";
     let binding = undefined;

--- a/lib/ui/notices.tsx
+++ b/lib/ui/notices.tsx
@@ -1,19 +1,19 @@
 
 export const LockStolenMessage = {
-  view({attrs: {workbench, finished}}) {
+  view() {
     return (
-      <div>
+      <form class="notice" method="dialog">
         <h3>Refresh to view latest updates</h3>
         <p>
           Your notes were updated in another browser session. Refresh the page to view the latest version.
         </p>
         <div class="button-bar">
           <button class="primary" onclick={() => {
-            finished();
+            location.reload()
           }}>Refresh Now</button>
           
         </div>
-      </div>
+      </form>
     )
   }
 }
@@ -21,7 +21,7 @@ export const LockStolenMessage = {
 export const FirstTimeMessage = {
   view({attrs: {workbench}}) {
     return (
-      <div>
+      <form class="notice" method="dialog">
         <h3>Treehouse is under active development</h3>
         <p>This is a preview based on our main branch, which is actively being developed.</p>
         <p>If you find a bug, please report it via 
@@ -38,11 +38,11 @@ export const FirstTimeMessage = {
         <div class="button-bar">
           <button class="primary" onclick={() => {
             localStorage.setItem("firsttime", "1");
-            workbench.hideNotice()
+            workbench.closeDialog();
           }}>Got it</button>
           
         </div>
-      </div>
+      </form>
     )
   }
 }
@@ -50,7 +50,7 @@ export const FirstTimeMessage = {
 export const GitHubMessage = {
   view({attrs: {workbench, finished}}) {
     return (
-      <div>
+      <form class="notice" method="dialog">
         <h3>Login with GitHub</h3>
         <p>The GitHub backend is experimental so use at your own risk!</p>
         <p>To store your workbench we will create a public repository called <pre style={{display: "inline"}}>&lt;username&gt;.treehouse.sh</pre> if it doesn't already exist. You can manually make this repository private via GitHub if you want.</p>
@@ -62,52 +62,15 @@ export const GitHubMessage = {
         </p>
         <div class="button-bar">
           <button onclick={() => {
-            workbench.hideNotice();
+            workbench.closeDialog();
           }}>Cancel</button>
           <button class="primary" onclick={() => {
-              workbench.hideNotice();
+              workbench.closeDialog();
               localStorage.setItem("github", "1");
               finished();
             }}>Log in with GitHub</button>
         </div>
-      </div>
-    )
-  }
-}
-
-export const Notice = {
-  view({attrs: {workbench, message, finished}}) {
-    return (
-      <div style={{
-        position: "absolute", 
-        left: "0", 
-        right: "0", 
-        top: "0", 
-        bottom: "0",
-      }}>
-        
-        <div style={{
-          position: "absolute",
-          background: "black",
-          opacity: "50%",
-          width: "100%",
-          height: "100%"
-        }}></div>
-        
-        <div class="notice" style={{
-          position: "relative",
-          marginLeft: "auto", 
-          marginRight: "auto",
-          filter: "drop-shadow(2px 2px 4px #5555)",
-          marginTop: "20vh", 
-        }}>
-          {m({
-            "firsttime": FirstTimeMessage,
-            "github": GitHubMessage,
-            "lockstolen": LockStolenMessage,
-          }[message], {workbench, finished})}
-        </div>
-      </div>
+      </form>
     )
   }
 }

--- a/lib/ui/palette.tsx
+++ b/lib/ui/palette.tsx
@@ -43,14 +43,14 @@ export const CommandPalette: m.Component = {
       if (e.key === "Enter") {
         if (state.selected !== undefined) {
           workbench.commands.executeCommand(filtered[state.selected].id, attrs.ctx);
-          workbench.hidePalette();
+          workbench.closeDialog();
         }
         return false;
       }
     }
     const onclick = (cmd) => {
       workbench.commands.executeCommand(cmd.id, attrs.ctx);
-      workbench.hidePalette();
+      workbench.closeDialog();
     }
     const autocomplete = (e) => {
       state.filter = e.target.value;
@@ -61,18 +61,14 @@ export const CommandPalette: m.Component = {
       return binding ? bindingSymbols(binding.key).join(" ").toUpperCase() : "";
     }
     return (
-      <div class="palette" style={{
-        position: "absolute",
-        left: `${attrs.x}px`,
-        top: `${attrs.y}px`
-      }}>
+      <div class="palette">
         <div><input style={{ width: "98%", outline: "0", border: "0" }} type="text" onkeydown={onkeydown} oninput={autocomplete} placeholder="Enter command..." /></div>
         <div class="commands" style={{
           overflowY: "scroll",
           position: "relative"
         }}>
           {filtered.map((cmd, idx) => (
-            <div class={(state.selected === idx) ? "selected" : ""} onclick={() => onclick(cmd)} style={{ display: "flex" }}>
+            <div class={(state.selected === idx) ? "selected" : ""} onclick={() => onclick(cmd)} style={{ display: "flex", cursor: "pointer" }}>
               <div>{cmd.title || cmd.id}</div>
               <div class="keybindings grow text-right">{getBindingSymbols(cmd)}</div>
             </div>

--- a/lib/ui/quickadd.tsx
+++ b/lib/ui/quickadd.tsx
@@ -2,41 +2,19 @@ import { OutlineEditor } from "./outline.tsx";
 import { Path } from "../workbench/mod.ts";
 
 export const QuickAdd = {
-  view({attrs: {workbench}}) {
-    const path = new Path(workbench.quickadd, "quickadd");
+  view({attrs: {workbench, node}}) {
+    const path = new Path(node, "quickadd");
     return (
-      <div style={{
-        position: "absolute", 
-        left: "0", 
-        right: "0", 
-        top: "0", 
-        bottom: "0",
-      }}>
-        
-        <div onclick={() => workbench.closeQuickAdd()} style={{
-          position: "absolute",
-          background: "black",
-          opacity: "50%",
-          width: "100%",
-          height: "100%"
-        }}></div>
-        
-        <div class="notice" style={{
-          position: "relative",
-          marginLeft: "auto", 
-          marginRight: "auto", 
-          marginTop: "20vh", 
-        }}>
+      <div class="notice">
           <h3>Quick Add</h3>
           <OutlineEditor workbench={workbench} path={path} />
           <div class="button-bar">
             <button class="primary" onclick={() => {
               workbench.commitQuickAdd();
-              workbench.closeQuickAdd();
+              workbench.closeDialog();
             }}>Add to Today</button>
             
           </div>
-        </div>
       </div>
     )
   }

--- a/web/static/app/main.css
+++ b/web/static/app/main.css
@@ -69,6 +69,23 @@ p {
   }
 }
 
+dialog {
+  filter: drop-shadow(2px 2px 4px #5555);
+  outline: none;
+  border: 1px solid var(--color-outline);
+  border-radius: var(--border-radius);
+  padding: 0;
+}
+dialog::backdrop {
+  background: rgba(0,0,0,0);
+}
+dialog.backdrop::backdrop {
+  background: rgba(0,0,0,0.25);
+}
+dialog > form {
+  padding: calc(2 * var(--padding));
+}
+
 ::placeholder {
   color: var(--color-text-placeholder) !important;
   opacity: 1;
@@ -293,9 +310,7 @@ svg.node-bullet circle#node-collapsed-handle {
 
 /*------------NOTICES------------*/
 .notice {
-  border-radius: var(--border-radius);
   width: 40rem;
-  padding: calc(var(--padding)*2);
   background-color: var(--color-background);
 }
 .notice h3 {
@@ -314,13 +329,10 @@ svg.node-bullet circle#node-collapsed-handle {
 
 /*------------MENU------------*/
 .menu {
-  border: 1px solid var(--color-outline);
-  border-radius: var(--border-radius);
   padding: calc(var(--padding)/4);
   background-color: var(--color-background);
   font-size: var(--text-small);
   min-width: 200px;
-  z-index: var(--layer-2);
 }
 .menu li {
   list-style-type: none;
@@ -341,12 +353,8 @@ svg.node-bullet circle#node-collapsed-handle {
 
 /*------------PALETTE------------*/
 .palette {
-  margin: 0;
-  border: 1px solid var(--color-outline);
-  border-radius: var(--border-radius);
   padding: var(--padding);
   min-width: 400px;
-  z-index: var(--layer-2);
   background: var(--color-background);
 }
 .palette, .palette input {
@@ -423,7 +431,7 @@ svg.node-bullet circle#node-collapsed-handle {
     --padding: var(--2);
   }
 
-  .notice {
+  dialog {
     width: 100vw;
   }
 /*todo: this padding needs to stay to same as desktop 

--- a/web/static/app/main.js
+++ b/web/static/app/main.js
@@ -6,4 +6,8 @@ setup(document, document.body, {
   "github": new GitHubBackend(`${window.backend.url}?scope=repo`, Octokit)
 }[window.backend.name]);
 
-
+setTimeout(() => {
+  if (!localStorage.getItem("firsttime")) {
+    window.workbench.showNotice('firsttime');
+  }
+}, 2000)


### PR DESCRIPTION
replaces modal code for quickadd, menus, palette, and notices with single dialog system using the dialog element. the search popover was not ported yet so curtain still remains. closes #158

@taramk I checked to make sure they all behave and are styled as before. however, while using `<dialog>` is *good* for limiting focus to whats in the dialog when its open, this does mean currently selected nodes will lose focus while a dialog is open. but i'm not sure that will break anything.