### PR TITLE
tweak sizing of node outer circles and icon

### DIFF
--- a/lib/com/search.tsx
+++ b/lib/com/search.tsx
@@ -27,9 +27,9 @@ export class SearchNode {
 
   handleIcon(collapsed: boolean = false): any {
     return (
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="node-bullet" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="node-bullet" width="15" height="15" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
         {collapsed?<circle id="node-collapsed-handle" stroke="none" cx="12" cy="12" r="12"/>:null}
-        <svg xmlns="http://www.w3.org/2000/svg" x="5" y="5" width="14" height="14" viewBox="0 0 24 24">
+        <svg xmlns="http://www.w3.org/2000/svg" x="3" y="3" width="19" height="19" viewBox="0 0 24 24">
           <circle cx="11" cy="11" r="8"></circle>
           <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
         </svg>

--- a/lib/ui/outline.tsx
+++ b/lib/ui/outline.tsx
@@ -177,9 +177,9 @@ export const OutlineNode: m.Component<Attrs, State> = {
             {(objectHas(node, "handleIcon"))
               ? objectCall(node, "handleIcon", subCount(node) > 0 && !expanded)
               : <svg class="node-bullet" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-                {(subCount(node) > 0 && !expanded)?<circle id="node-collapsed-handle" cx="8" cy="7" r="7" />:null}
-                <circle cx="8" cy="7" r="3" fill="currentColor" />,
-                {(isRef)?<circle id="node-reference-handle" cx="8" cy="7" r="7" fill="none" stroke-width="1" stroke="currentColor" stroke-dasharray="3,3" />:null}
+                {(subCount(node) > 0 && !expanded)?<circle id="node-collapsed-handle" cx="8" cy="8" r="8" />:null}
+                <circle cx="8" cy="8" r="3" fill="currentColor" />,
+                {(isRef)?<circle id="node-reference-handle" cx="8" cy="8" r="7" fill="none" stroke-width="1" stroke="currentColor" stroke-dasharray="3,3" />:null}
               </svg>
             }
           </div>


### PR DESCRIPTION
closes #188 

* make node outer circles the same consistent size
* increase size/stroke of search icon for legibility
* update reference node to match

i guess these should all use the same style, but i barely understand how this svg sizing stuff works so i'm not sure how to do that. should it be a CSS class? or a single element in the code? some of the icons may need to be sized/aligned by hand within a frame, but the outer circle should always be the same.

Before and after:

![Image](https://github.com/treehousedev/treehouse/assets/1813419/0230422a-143f-4997-ae14-b06c61bd02bb)