### PR TITLE
pass at updating mobile styles/sizing

### DIFF
--- a/lib/ui/app.tsx
+++ b/lib/ui/app.tsx
@@ -159,8 +159,8 @@ const NavNode: m.Component = {
     }
     return (
       <div>
-        <div style={{display: "flex", paddingBottom: "var(--2)" }}>
-          <svg onclick={toggle} style={{cursor: "pointer", flexShrink: "0", paddingTop: "0px", marginRight: "0.125rem"}} class="feather feather-chevron-right" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">          
+        <div class="sidebar-item flex">
+          <svg onclick={toggle} class="feather feather-chevron-right shrink-0" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">          
             {(expandable)
                 ?(state.expanded)
                   ? <polyline points="6 9 12 15 18 9"></polyline>
@@ -168,12 +168,12 @@ const NavNode: m.Component = {
               :null}
           </svg>
           
-          <div onclick={open} style={{cursor: "pointer", lineHeight: "1.25", fontSize: "0.875rem", flexGrow: "1", maxWidth: "100%", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap"}}>
+          <div class="sidebar-item-label grow" onclick={open} style={{cursor: "pointer", maxWidth: "100%", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap"}}>
             {node.name}
           </div>
         </div>
         {state.expanded && 
-          <div style={{marginLeft: "0.5rem"}}>
+          <div class="sidebar-item-nested">
             {node.children.filter(n => n.name !== "").map(n => <NavNode workbench={workbench} node={n} level={level+1} />)}
           </div>
         }

--- a/lib/ui/search.tsx
+++ b/lib/ui/search.tsx
@@ -20,8 +20,8 @@ export const Search: m.Component = {
       <div class="search">
         <Picker onpick={onpick} onchange={onchange} input={input}
           inputview={(onkeydown, oninput, value) => 
-            <div class="flex">
-              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-search shrink-0"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
+            <div class="flex items-center">
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-search shrink-0 items-center"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
               <input type="text" placeholder="Search" value={value} onkeydown={onkeydown} oninput={oninput} />
             </div>
           }

--- a/web/static/app/main.css
+++ b/web/static/app/main.css
@@ -35,7 +35,7 @@ body {
 }
 body, input, textarea, button {
   color: var(--color-text);
-  font-size: 1rem;
+  font-size: var(--text-body);
   font-family: var(--font);
   font-weight: var(--weight-regular);
 }
@@ -91,7 +91,7 @@ dialog > form {
   opacity: 1;
 }
 
-/*------------APP------------
+/*------------APP------------*/
 
 main {
   background-color: var(--color-background);
@@ -110,23 +110,32 @@ main {
   padding: var(--padding);
   border-bottom: 1px solid var(--color-outline-secondary);
 }
-/*TO DO: change logo to SVG and set color instead of opacity*/
 .sidebar-top > .logo {
-/*  height: 20px;
-  width: 20px;*/
   color: var(--color-icon-secondary);
 }
 .sidebar-main {
   padding: var(--padding);
   font-weight: var(--weight-semibold);
+  font-size: var(--text-small);
   color: var(--color-nav-label);
 }
 .sidebar-main svg {
   color: var(--color-icon);
 }
+.sidebar-item {
+  padding-bottom: calc(var(--padding)/2);
+}
+.sidebar-item svg {
+  cursor: pointer;
+  padding-top: 0px;
+  margin-right: 0.125rem;
+}
 .sidebar-bottom {
   padding: var(--padding);
   color: var(--color-icon-secondary);
+}
+.sidebar-item-nested {
+  margin-left: 0.5rem;
 }
 
 /*------------TOPBAR------------*/
@@ -456,11 +465,24 @@ svg.node-bullet circle#node-collapsed-handle {
 
   :root {
     --padding: var(--2);
+    --text-small: 1.125rem;
+    --text-body: 1.25rem;
   }
 
+/*to account for small margin on either side of dialog*/
   dialog {
-    width: 100vw;
-    max-width: 100vw;
+    width: 97vw;
+    max-width: 97vw;
+  }
+  dialog:has(> .search) {
+    margin: 0 auto !important;
+  }
+  dialog:has(> .menu) {
+    margin-left: auto !important;
+    margin-right: auto !important;
+  }
+  .menu {
+    width: 100%;
   }
 /*todo: this padding needs to stay to same as desktop 
 for alignment purposes. should probably center
@@ -477,11 +499,20 @@ the top nav in a more elegant way at some point*/
     z-index: 10;
     height: 100%;
     display: none;
+    padding: calc(var(--padding)*2);
+  }
+
+  .sidebar-item {
+    padding-bottom: calc(var(--padding)*2);
   }
  
-  .search {
+/*  .search {
     max-width: 100vw;
+  }*/
 
+  .sidebar, .panel {
+    padding-top: calc(var(--padding)*3);
+    padding-bottom: calc(var(--padding)*3);
   }
   svg.node-menu{
     width: 1.5rem;

--- a/web/static/style/design.css
+++ b/web/static/style/design.css
@@ -80,6 +80,7 @@
 
   --body-line-height: 1.5;
   --text-small: 0.875rem;
+  --text-body: 1rem;
 
   --padding: 1rem;
 


### PR DESCRIPTION
closes #198 

* add padding around sidebar and panels
* increase body font size and nav/secondary font size
* center dialogs horizontally (user menu, node menu, search)
* move sidebar inline styles to CSS

there will be more tweaks coming but this is a good first step to make the tap areas a better size and create some structure in the mobile CSS styles.