### PR TITLE
fix dark mode primary color

### DIFF
--- a/web/static/style/themes/darkmode.css
+++ b/web/static/style/themes/darkmode.css
@@ -2,7 +2,7 @@
 :root {
   --font: 'Figtree', sans-serif;
 
-  --color-primary: purple;
+  --color-primary: var(--white);
 
   --color-background: var(--black);
   --color-background-sidebar: var(--gray-800);


### PR DESCRIPTION
the purple had terrible contrast with the dark background, doing white for now. we only use the primary color for the primary button on modals at the moment.