### PR TITLE
lib: ignore control, shift, alt, meta keys

### DIFF
--- a/lib/ui/app.tsx
+++ b/lib/ui/app.tsx
@@ -52,7 +52,7 @@ export const App: m.Component = {
                   <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-search shrink-0"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
                   <input type="text" placeholder="Search" 
                     onkeydown={(e) => {
-                      if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) return;
+                      if (e.key === 'Control' || e.key === 'Alt' || e.key === 'Shift' || e.key === 'Meta') return;
                       const input = e.target.getBoundingClientRect();
                       workbench.showDialog(() => <Search workbench={workbench} input={e.key} />, false, {
                         // TODO: make these not so hardcoded offsets


### PR DESCRIPTION
This ignores the special keys (control, shift, alt, meta) themselves instead of any keys with those modifiers set.

Fixes #217 

@taramk 