### PR TITLE
ui: replace forms with divs

### DIFF
--- a/lib/ui/notices.tsx
+++ b/lib/ui/notices.tsx
@@ -2,7 +2,7 @@
 export const LockStolenMessage = {
   view() {
     return (
-      <form class="notice" method="dialog">
+      <div class="notice" method="dialog">
         <h3>Refresh to view latest updates</h3>
         <p>
           Your notes were updated in another browser session. Refresh the page to view the latest version.
@@ -13,7 +13,7 @@ export const LockStolenMessage = {
           }}>Refresh Now</button>
           
         </div>
-      </form>
+      </div>
     )
   }
 }
@@ -21,7 +21,7 @@ export const LockStolenMessage = {
 export const FirstTimeMessage = {
   view({attrs: {workbench}}) {
     return (
-      <form class="notice" method="dialog">
+      <div class="notice" method="dialog">
         <h3>Treehouse is under active development</h3>
         <p>This is a preview based on our main branch, which is actively being developed.</p>
         <p>If you find a bug, please report it via 
@@ -42,7 +42,7 @@ export const FirstTimeMessage = {
           }}>Got it</button>
           
         </div>
-      </form>
+      </div>
     )
   }
 }
@@ -50,7 +50,7 @@ export const FirstTimeMessage = {
 export const GitHubMessage = {
   view({attrs: {workbench, finished}}) {
     return (
-      <form class="notice" method="dialog">
+      <div class="notice" method="dialog">
         <h3>Login with GitHub</h3>
         <p>The GitHub backend is experimental so use at your own risk!</p>
         <p>To store your workbench we will create a public repository called <pre style={{display: "inline"}}>&lt;username&gt;.treehouse.sh</pre> if it doesn't already exist. You can manually make this repository private via GitHub if you want.</p>
@@ -70,7 +70,7 @@ export const GitHubMessage = {
               finished();
             }}>Log in with GitHub</button>
         </div>
-      </form>
+      </div>
     )
   }
 }

--- a/lib/ui/quickadd.tsx
+++ b/lib/ui/quickadd.tsx
@@ -5,7 +5,7 @@ export const QuickAdd = {
   view({attrs: {workbench, node}}) {
     const path = new Path(node, "quickadd");
     return (
-      <form class="notice" method="dialog">
+      <div class="notice" method="dialog">
           <h3>Quick Add</h3>
           <OutlineEditor workbench={workbench} path={path} alwaysShowNew={true} />
           <div class="button-bar">
@@ -15,7 +15,7 @@ export const QuickAdd = {
             }}>Add to Today</button>
             
           </div>
-      </form>
+      </div>
     )
   }
 }

--- a/lib/ui/settings.tsx
+++ b/lib/ui/settings.tsx
@@ -3,7 +3,7 @@ export const Settings = {
   view({attrs: {workbench}}) {
     const currentTheme = workbench.workspace.settings.theme;
     return (
-      <form class="notice" method="dialog">
+      <div class="notice" method="dialog">
           <h3>Settings</h3>
           <div class="flex flex-row">
             <div class="grow">Theme</div>
@@ -31,7 +31,7 @@ export const Settings = {
               }
             }}>Save Changes</button>
           </div>
-      </form>
+      </div>
     )
   }
 }

--- a/web/static/app/main.css
+++ b/web/static/app/main.css
@@ -287,6 +287,7 @@ svg.node-bullet circle#node-collapsed-handle {
 .notice {
   width: 40rem;
   background-color: var(--color-background);
+  padding: calc(var(--padding)*2);
 }
 .notice h3 {
   margin-bottom: calc(var(--padding)*1.5);


### PR DESCRIPTION
This replaces all forms with class `notice` to divs, and adds some padding to the class.

Closes #201 