### PR TITLE
lib: add link to documentation

### DIFF
--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -550,6 +550,7 @@ export async function setup(document: Document, target: HTMLElement, backend: Ba
       }
     },
     { title: () => "Settings", onclick: () => workbench.showSettings() },
+    { title: () => "Documentation", onclick: () => window.open("https://treehouse.sh/docs", "_blank") },
     { title: () => "Submit Issue", onclick: () => window.open("https://github.com/treehousedev/treehouse/issues", "_blank") },
     { title: () => "Logout", when: () => workbench.authenticated(), onclick: () => workbench.backend.auth.logout() },
   ]);


### PR DESCRIPTION
Closes #175 

@taramk : The figma docs show an "external link" icon next to the word Documentation, but I noticed none of the other links have icons, so I didn't try to put it in. Let me know if you want me to add icons to this and the "Submit Issue" links.