### PR TITLE
lib: use combineWith when searching

### DIFF
--- a/lib/backend/browser.ts
+++ b/lib/backend/browser.ts
@@ -48,7 +48,10 @@ export class SearchIndex_MiniSearch {
   search(query: string): string[] {
     const suggested = this.indexer.autoSuggest(query);
     if (suggested.length === 0) return [];
-    return this.indexer.search(suggested[0].suggestion, {prefix: true}).map(doc => doc.ID);
+    return this.indexer.search(suggested[0].suggestion, {
+      prefix: true,
+      combineWith: 'AND',
+    }).map(doc => doc.ID);
   }
 }
 


### PR DESCRIPTION
Fixes #197 

By default, `MiniSearch` searches all of the words in the query independently, which means a search for something like 'sweet thai' searches for any matches (including in all Node fields) for either the words 'sweet' or 'thai'. It seems to make the search results too broad. This changes the search options to include `combineWith: 'AND'`, which narrows the results.

I'm not sure if this goes too far in the other direction though. Let me know @taramk 