### PR TITLE
update tag colors to use theme variables

### DIFF
--- a/lib/com/tag.tsx
+++ b/lib/com/tag.tsx
@@ -111,7 +111,7 @@ const TagBadge = {
       }
     };
     return (
-      <button class="badge flex flex-row items-center" onkeydown={onkeydown} style={{background: "gray", lineHeight: "var(--body-line-height)", paddingLeft: "0.25rem", paddingRight: "0.25rem", borderRadius: "4px", color: "white"}}>
+      <button class="badge flex flex-row items-center" onkeydown={onkeydown} >
         <svg style={{width: "1rem", height: "1rem", marginRight: "0.25rem"}} xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-tag"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"></path><line x1="7" y1="7" x2="7.01" y2="7"></line></svg>
         <div style={{whiteSpace: "nowrap"}}>{component.name}</div>
       </button>

--- a/web/static/app/main.css
+++ b/web/static/app/main.css
@@ -42,14 +42,17 @@ body, input, textarea, button {
 dialog {
   color: var(--color-text);
 }
+/*shared button styles including tags (badges)*/
+button {
+  cursor: pointer; 
+  border-radius: var(--border-radius);
+}
 button:not(.badge) {
   box-sizing: content-box;
   height: 48px;
   font-weight: var(--weight-bold);
   border: 1px solid var(--color-outline);
-  border-radius: var(--border-radius);
   background-color: var(--color-background);
-  cursor: pointer; 
   padding: 0 calc(var(--padding)*2);
 }
 button.primary {
@@ -58,11 +61,13 @@ button.primary {
   border: none;
 }
 button.badge {
-  padding: 0;
-  border: 1px solid gray;
+  padding: 0 var(--1);
+  border: 1px solid var(--color-background);
+  background: var(--color-highlight);
+  line-height: var(--body-line-height);
 }
 button.badge:focus {
-  border: 1px solid blue;
+  border: 1px solid var(--color-outline);
 }
 p {
   margin-block-start: var(--padding);


### PR DESCRIPTION
closes #230 

uses existing theme variables in a way that ensures the best contrast

<img width="139" alt="image" src="https://github.com/treehousedev/treehouse/assets/1813419/24dddd91-9189-48dc-8a6a-bc4380c6b965">
