### PR TITLE
ui: improve table view styling

### DIFF
--- a/lib/view/table.tsx
+++ b/lib/view/table.tsx
@@ -17,7 +17,7 @@ export default {
       <table class="table-view" style={{gridTemplateColumns: `repeat(${state.fields.size+1}, 1fr)`}}>
         <thead>
           <tr>
-            <th></th>
+            <th>Title</th>
             {[...state.fields].map(f => <th>{f}</th>)}
           </tr>
         </thead>

--- a/web/static/app/main.css
+++ b/web/static/app/main.css
@@ -295,14 +295,21 @@ svg.node-bullet circle#node-collapsed-handle {
 
 .table-view {
   display: grid;
+  margin-bottom: calc(var(--padding)/4);
 }
 .table-view th {
+  border-bottom: solid 1px var(--color-outline-secondary);
+  margin-bottom: calc(var(--padding)/2);
+  padding-bottom: calc(var(--padding)/2);
   text-align: left;
 }
 .table-view thead,
 .table-view tbody,
 .table-view tr {
   display: contents;
+}
+.table-view thead th:first-child {
+  padding-left: 24px;
 }
 
 /*------------NOTICES------------*/


### PR DESCRIPTION
Closes #210 

This adds padding to the front of the `:first-child` th element in the table (for the "Title" text alignment) to match the width and padding of the handles in the elements below. It would be nice if it wasn't just a hardcoded px width (so we don't have to remember to change it if the handle sizes change), but I don't know of a better way of doing it yet. Let me know what you think @taramk 