### PR TITLE
swap out svg for hashtag, minor style updates

### DIFF
--- a/lib/com/tag.tsx
+++ b/lib/com/tag.tsx
@@ -112,7 +112,7 @@ const TagBadge = {
     };
     return (
       <div tabindex="1" class="badge flex flex-row items-center" onkeydown={onkeydown} >
-        <svg style={{width: "1rem", height: "1rem", marginRight: "0.25rem"}} xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-tag"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"></path><line x1="7" y1="7" x2="7.01" y2="7"></line></svg>
+        <span>#&nbsp;</span>
         <div style={{whiteSpace: "nowrap"}}>{component.name}</div>
       </div>
     )

--- a/web/static/app/main.css
+++ b/web/static/app/main.css
@@ -65,9 +65,13 @@ button.primary {
   border: 1px solid var(--color-background);
   background: var(--color-highlight);
   line-height: var(--body-line-height);
+  font-size: var(--text-small);
 }
 .badge:focus {
   border: 1px solid var(--color-outline);
+}
+.badge span {
+  color: var(--color-icon-secondary);
 }
 
 p {


### PR DESCRIPTION
* swap out tag icon for hashtag
* make hashtag color slightly lower contrast (use secondary icon variable, works for all themes)
* make tag text slightly smaller in size (tags are secondary information and should be visually treated as such)

<img width="906" alt="image" src="https://github.com/treehousedev/treehouse/assets/1813419/32ba6442-ddcd-459c-af92-04543511bac5">
