### PR TITLE
Update docs link in app

### DIFF
--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -670,7 +670,7 @@ export async function setup(document: Document, target: HTMLElement, backend: Ba
       }
     },
     { title: () => "Settings", onclick: () => workbench.showSettings() },
-    { title: () => "Documentation", onclick: () => window.open("https://treehouse.sh/docs", "_blank") },
+    { title: () => "Documentation", onclick: () => window.open("https://treehouse.sh/docs/user", "_blank") },
     { title: () => "Submit Issue", onclick: () => window.open("https://github.com/treehousedev/treehouse/issues", "_blank") },
     { title: () => "Logout", when: () => workbench.authenticated(), onclick: () => workbench.backend.auth.logout() },
   ]);


### PR DESCRIPTION
should go to user guide rather than just docs (which links to quick start)

closes #241 