### PR TITLE
change all instances of live search to smart nodes

### DIFF
--- a/web/blog/v0-3-0.md
+++ b/web/blog/v0-3-0.md
@@ -8,6 +8,8 @@ date: "2023-05-17"
 
 This release we added some exciting new features: Fields, Live Search, and References. These new node types represent our first step into becoming much more than a simple outliner. Quality of live improvements include making the node menu easier to click, initial work towards a mobile view, and improving interactivity of the command palette. We also cleaned up all our UI elements to match our design system, allowing for better custom CSS support.
 
+*Update 7/10/2023: Live Search is now called Smart Nodes*
+
 [![Watch Demo](http://i3.ytimg.com/vi/PjWibMkKBOE/hqdefault.jpg)](https://www.youtube.com/watch?v=PjWibMkKBOE)
 [Demo video](https://www.youtube.com/watch?v=PjWibMkKBOE)
 

--- a/web/blog/v0-4-0.md
+++ b/web/blog/v0-4-0.md
@@ -10,7 +10,7 @@ In this release we focused on making Treehouse more powerful and enjoyable to us
 
 White background a bit too bright? We've added several built-in themes (including sepia and dark mode) *and* we've made it super easy to [create your own CSS themes](https://treehouse.sh/docs/user/#css-theming) using our component variables.
 
-Otherwise, lots of quality of life improvements as usual, especially for fields and live search nodes.
+Otherwise, lots of quality of life improvements as usual, especially for fields and Smart Nodes.
 
 [![Watch Demo](http://i3.ytimg.com/vi/byZnYzzrP7E/hqdefault.jpg)](https://www.youtube.com/watch?v=byZnYzzrP7E)
 [Demo video](https://www.youtube.com/watch?v=byZnYzzrP7E)

--- a/web/blog/v0-5-0.md
+++ b/web/blog/v0-5-0.md
@@ -8,7 +8,7 @@ date: "2023-07-06"
 
 Treehouse now supports tags and templates! For example, you can now create a template node with children and fields, name it "book", then any node tagged with #book will automatically get those fields and children. To turn a node into a template, select "Make Template" from the Command Palette. You can also tag nodes without an equivalent template. Tagging is done by simply adding hashtags to a node's text. 
 
-You can search for tagged nodes in the search bar using the hashtag notation (#book), however there is a known issue preventing you from searching for nodes by tag in Live Search. This will be resolved in the next release, and in `main` much sooner.
+You can search for tagged nodes in the search bar using the hashtag notation (#book), however there is a known issue preventing you from searching for nodes by tag in Smart Nodes. This will be resolved in the next release, and in `main` much sooner.
 
 You can now take a list of nodes with fields and turn them into an easy-to-scan table. Simply go to the parent node of the rows, open the Command Palette with Command+K, and choose "View as Table". We'll be adding more features to the table view in coming releases.
 

--- a/web/docs/user.md
+++ b/web/docs/user.md
@@ -77,7 +77,7 @@ You can close or expand either panel to return to a single panel view.
 
 ## Fields
 
-A **field** is a node that can store structured information. Fields provide your data with structure, and allow for special search syntax (see [Live Search](#live-search)).
+A **field** is a node that can store structured information. Fields provide your data with structure, and allow for special search syntax (see [Smart Nodes](#smart-nodes)).
 
 ### Create a field
 
@@ -86,16 +86,17 @@ To add a field to a node:
 2. Use Command/Control + K to open the command palette, and choose "Create field"
 3. Add your field value in the value section
 
-## Live Search
+## Smart Nodes
 
-Live Search allow you to create an auto-updating search of all the nodes in your workspace. Simply type your search term, or use the format "fieldname:valuename" to filter specifically by field values. The Live Search will update automatically as your node content changes. This is a simple but super powerful way to view your data in new configurations.
+Smart Nodes allow you to create an auto-updating search of all the nodes in your workspace. Simply type your search term, or use the format "fieldname:valuename" to filter specifically by field values. The Smart Node will update automatically as your node content changes. This is a simple but super powerful way to view your data in new configurations.
 
-To create a search node:
-1. Create a new node where you want your search node, and type your search value
-2. Use Command/Control + K to open the command palette, and choose "Create Search Node"
+To create a Smart Node:
+1. Create a new node where you want your Smart Node, and type your search value
+2. Use Command/Control + K to open the command palette, and choose "Create Smart Node"
 
-### Tips for using Live Search
+### Tips for using Smart Nodes
 * You can filter on multiple fieldname values (using AND, not OR) like so: "fieldname:valuename fieldname:valuename" etc.
+* If your fieldname has spaces, put quotes around it (fieldname:"Value name")
 * Search terms are case-insensitive
 
 ## Calendar 

--- a/web/index.tsx
+++ b/web/index.tsx
@@ -83,7 +83,7 @@ export default (data) => (
       <div class="flex flex-col gap-8 md:gap-16 md:flex-row">
         <div class="flex flex-col flex-1">
           <img class="bg-gray-400 image h-64 mb-6 object-cover object-left" src="/photos/live-search.png" />
-          <h3>Fields and Live Search</h3>
+          <h3>Fields and Smart Nodes</h3>
           <p>Add metadata, then create a custom search view.</p>
         </div>
 


### PR DESCRIPTION
closes #248 

replaced all names except 0.3.0 where i added a note about the name change, because we refer to it as Live Search in the demo video and i didn't want that to be confusing