### PR TITLE
lib: clean up command palette commands

### DIFF
--- a/lib/action/commands.ts
+++ b/lib/action/commands.ts
@@ -4,6 +4,7 @@ export interface Command {
   title?: string;
   category?: string;
   icon?: string;
+  hidden?: boolean;
   action: Function;
   when?: Function;
 }

--- a/lib/com/tag.tsx
+++ b/lib/com/tag.tsx
@@ -21,6 +21,7 @@ export class Tag {
     workbench.commands.registerCommand({
       id: "add-tag",
       title: "Add tag",
+      hidden: true,
       action: (ctx: Context, name: string) => {
         if (!ctx.node) return;
         const tag = new Tag(name);

--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -565,6 +565,7 @@ export async function setup(document: Document, target: HTMLElement, backend: Ba
   workbench.keybindings.registerBinding({ command: "next", key: "arrowdown" });
   workbench.commands.registerCommand({
     id: "pick-command",
+    hidden: true,
     action: (ctx: Context) => {
       let node = ctx.node;
       let path = ctx.path;

--- a/lib/ui/palette.tsx
+++ b/lib/ui/palette.tsx
@@ -4,8 +4,13 @@ import { Picker } from "./picker.tsx";
 export const CommandPalette: m.Component = {
 
   view({ attrs: { workbench, ctx } }) {
-    const cmds = Object.values(workbench.commands.commands);
-    
+    const getTitle = (cmd) => {
+      const title = cmd.title || cmd.id;
+      return title.replace('-', ' ').replace(/(^|\s)\S/g, t => t.toUpperCase());
+    }
+    const sort = (a, b) => {
+      return getTitle(a).localeCompare(getTitle(b));
+    }
     const onpick = (cmd) => {
       workbench.closeDialog();
       workbench.commands.executeCommand(cmd.id, ctx);
@@ -20,6 +25,9 @@ export const CommandPalette: m.Component = {
       const binding = workbench.keybindings.getBinding(cmd.id);
       return binding ? bindingSymbols(binding.key).join(" ").toUpperCase() : "";
     }
+
+    const cmds = Object.values(workbench.commands.commands).filter(cmd => !cmd.hidden).sort(sort);
+
     return (
       <div class="palette">
         <Picker onpick={onpick} onchange={onchange}
@@ -30,7 +38,7 @@ export const CommandPalette: m.Component = {
           }
           itemview={(cmd) => 
             <div class="flex">
-              <div>{cmd.title || cmd.id}</div>
+              <div>{getTitle(cmd)}</div>
               <div class="keybindings grow text-right">{getBindingSymbols(cmd)}</div>
             </div>
           } />


### PR DESCRIPTION
Fixes #242 

- Adds a `hidden` attribute to `Command`. This was mentioned in the ticket and seemed better than maintaining a list of ids to filter
- Uses a regex to help with title case: `/(^|\s)\S/g` (first letter after whitespace or the beginning of a line)
- Sorts everything in the command palette no matter what. Let me know if it looks good @taramk 