### PR TITLE
Remove cut nodes from view

### DIFF
--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -94,10 +94,6 @@ export async function setup(document: Document, target: HTMLElement, backend: Ba
       return false;
     },
     action: (ctx: Context) => {
-      ctx.node.setAttr("cut", "true");
-      if (workbench.clipboard && workbench.clipboard.node) {
-        workbench.clipboard.node.setAttr("cut", "false");
-      }
       workbench.clipboard = {op: "cut", node: ctx.node};
     }
   });
@@ -122,9 +118,6 @@ export async function setup(document: Document, target: HTMLElement, backend: Ba
       return false;
     },
     action: (ctx: Context) => {
-      if (workbench.clipboard && workbench.clipboard.node) {
-        workbench.clipboard.node.setAttr("cut", "false");
-      }
       workbench.clipboard = {op: "copy", node: ctx.node};
     }
   });
@@ -149,9 +142,6 @@ export async function setup(document: Document, target: HTMLElement, backend: Ba
       return false;
     },
     action: (ctx: Context) => {
-      if (workbench.clipboard && workbench.clipboard.node) {
-        workbench.clipboard.node.setAttr("cut", "false");
-      }
       workbench.clipboard = {op: "copyref", node: ctx.node};
     }
   });
@@ -169,9 +159,6 @@ export async function setup(document: Document, target: HTMLElement, backend: Ba
     action: (ctx: Context) => {
       if (!ctx.node) return;
       if (ctx.path.previous && objectManaged(ctx.path.previous)) return;
-      if (workbench.clipboard && workbench.clipboard.node) {
-        workbench.clipboard.node.setAttr("cut", "false");
-      }
       switch (workbench.clipboard.op) {
         case "copy":
           workbench.clipboard.node = workbench.clipboard.node.duplicate();

--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -94,6 +94,10 @@ export async function setup(document: Document, target: HTMLElement, backend: Ba
       return false;
     },
     action: (ctx: Context) => {
+      ctx.node.setAttr("cut", "true");
+      if (workbench.clipboard && workbench.clipboard.node) {
+        workbench.clipboard.node.setAttr("cut", "false");
+      }
       workbench.clipboard = {op: "cut", node: ctx.node};
     }
   });
@@ -118,6 +122,9 @@ export async function setup(document: Document, target: HTMLElement, backend: Ba
       return false;
     },
     action: (ctx: Context) => {
+      if (workbench.clipboard && workbench.clipboard.node) {
+        workbench.clipboard.node.setAttr("cut", "false");
+      }
       workbench.clipboard = {op: "copy", node: ctx.node};
     }
   });
@@ -142,6 +149,9 @@ export async function setup(document: Document, target: HTMLElement, backend: Ba
       return false;
     },
     action: (ctx: Context) => {
+      if (workbench.clipboard && workbench.clipboard.node) {
+        workbench.clipboard.node.setAttr("cut", "false");
+      }
       workbench.clipboard = {op: "copyref", node: ctx.node};
     }
   });
@@ -159,6 +169,9 @@ export async function setup(document: Document, target: HTMLElement, backend: Ba
     action: (ctx: Context) => {
       if (!ctx.node) return;
       if (ctx.path.previous && objectManaged(ctx.path.previous)) return;
+      if (workbench.clipboard && workbench.clipboard.node) {
+        workbench.clipboard.node.setAttr("cut", "false");
+      }
       switch (workbench.clipboard.op) {
         case "copy":
           workbench.clipboard.node = workbench.clipboard.node.duplicate();

--- a/lib/ui/outline.tsx
+++ b/lib/ui/outline.tsx
@@ -35,6 +35,7 @@ export const OutlineNode: m.Component<Attrs, State> = {
   view ({attrs, state, children}) {
     let {path, workbench} = attrs;
     let node = path.node;
+    let isCut = node.getAttr("cut") === "true";
 
     let isRef = false;
     let handleNode = node;
@@ -209,7 +210,7 @@ export const OutlineNode: m.Component<Attrs, State> = {
     }
 
     return (
-      <div onmouseover={hover} onmouseout={unhover} id={`node-${path.id}-${handleNode.id}`}>
+      <div onmouseover={hover} onmouseout={unhover} id={`node-${path.id}-${handleNode.id}`} class={isCut ? "cut-node" : ""}>
         <div class="node-row-outer-wrapper flex flex-row items-start">
           <svg class="node-menu shrink-0" xmlns="http://www.w3.org/2000/svg"
               onclick={(e) => workbench.showMenu(e, {node: handleNode, path})}

--- a/lib/ui/outline.tsx
+++ b/lib/ui/outline.tsx
@@ -35,13 +35,19 @@ export const OutlineNode: m.Component<Attrs, State> = {
   view ({attrs, state, children}) {
     let {path, workbench} = attrs;
     let node = path.node;
-    let isCut = node.getAttr("cut") === "true";
 
     let isRef = false;
     let handleNode = node;
     if (node.refTo) {
       isRef = true;
       node = handleNode.refTo;
+    }
+
+    let isCut = false;
+    if (workbench.clipboard && workbench.clipboard.op === "cut") {
+      if (workbench.clipboard.node.id === node.id) {
+        isCut = true;
+      }
     }
 
     const expanded = workbench.workspace.getExpanded(path.head, handleNode);

--- a/web/static/app/main.css
+++ b/web/static/app/main.css
@@ -274,6 +274,9 @@ with their icon for Safari only*/
 .expanded-node > .indent {
   width: var(--8);
 }
+.cut-node {
+  display: none;
+}
 svg.node-menu {
   cursor: pointer;
   color: var(--color-node-handle);


### PR DESCRIPTION
This adds a new `cut` attr to nodes when they're cut, and adds a `cut-node` class that sets display to none.

@taramk let me know how you feel about it.

Closes #274 