### PR TITLE
lib: compensate for duplicate nodes in path

### DIFF
--- a/lib/ui/panel.tsx
+++ b/lib/ui/panel.tsx
@@ -12,7 +12,12 @@ export const Panel = {
       workbench.executeCommand("close-panel", {}, path);
     }
     const goBack = (e) => {
-      path.pop();
+      let node = path.pop();
+      // if there was a duplicate id in the path,
+      // pop again
+      if (node === path.node) {
+        path.pop();
+      }
     }
     const maximize = (e) => {
       // todo: should be a command


### PR DESCRIPTION
When hitting the back button in a panel, there may be a duplicate node id in the path. This change `pop`s again if the node is still in the path, which fixes having to click the button twice.

I started looking into why this is happening the in the first place, but I haven't figured it out yet. I thought it might help to make a command for the "back" behavior and add this there (and maybe also set `workspace.lastOpenedID` too?), but I didn't know if that made sense to do before figuring out what the actual problem is first. Anyway, I thought I should get this small change out for review now. Let me know what you think @progrium 