### PR TITLE
lib: insert child on new node keydown

### DIFF
--- a/lib/ui/node/new.tsx
+++ b/lib/ui/node/new.tsx
@@ -1,10 +1,7 @@
 
 export const NewNode = {
   view({attrs: {workbench, path}}) {
-    const startNew = (e) => {
-      workbench.executeCommand("insert-child", {node: path.node, path}, e.target.value);
-    }
-    const tabNew = (e) => {
+    const keydown = (e) => {
       if (e.key === "Tab") {
         e.stopPropagation();
         e.preventDefault();
@@ -12,6 +9,8 @@ export const NewNode = {
           const lastchild = path.node.children[path.node.childCount-1];
           workbench.executeCommand("insert-child", {node: lastchild, path});
         }
+      } else {
+        workbench.executeCommand("insert-child", {node: path.node, path}, e.target.value);
       }
     }
     return (
@@ -23,8 +22,7 @@ export const NewNode = {
         <div class="flex grow">
           <input class="grow"
             type="text"
-            oninput={startNew}
-            onkeydown={tabNew}
+            onkeydown={keydown}
             value={""}
           />
         </div>


### PR DESCRIPTION
Fixes #275 

This one is kinda tricky. The ticket says the issue is with pasting into a new node. Here's what I did in my testing:

1. Copy a node
2. Open (`zoom` command) an existing node with no children
3. Hit Command + K (`pick-command` command)

The last step fails.

Reason:

Opening a node with no children shows a panel with a `NewNode` as the body. The `NewNode` doesn't exist in the workspace yet. The actual node isn't created until a character is entered (`oninput`). Pressing Command + K doesn't count as `oninput`, so when the `pick-command` action is run, it sees that there's no node in context, and as a backup, it tries to set the context to the current path head. After `zoom` though, the path head isn't on the screen any more, so it crashes since the input control it's expecting isn't on screen.

Proposal:

This PR just creates the node (runs `insert-child`) any time a key is pressed (onkeydown), not just when an actual character is entered (oninput). Now, as soon as the user tries to Command + K, the actual node will be created, then they can actually paste.

I'm not sure this is how you actually want things to work though, so let me know what you think @progrium @taramk 