### PR TITLE
lib: clear clipboard on paste

### DIFF
--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -180,7 +180,9 @@ export async function setup(document: Document, target: HTMLElement, backend: Ba
       const p = ctx.path.clone();
       p.pop();
       workbench.focus(p.append(workbench.clipboard.node));
-      workbench.clipboard = undefined;
+      if (workbench.clipboard.op === "cut") {
+        workbench.clipboard = undefined;
+      }
     }
   });
   workbench.keybindings.registerBinding({ command: "paste", key: "meta+v" });

--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -180,6 +180,7 @@ export async function setup(document: Document, target: HTMLElement, backend: Ba
       const p = ctx.path.clone();
       p.pop();
       workbench.focus(p.append(workbench.clipboard.node));
+      workbench.clipboard = undefined;
     }
   });
   workbench.keybindings.registerBinding({ command: "paste", key: "meta+v" });


### PR DESCRIPTION
Fixes #293 

In some circumstances, the logic that hides a cut node will also hide a newly pasted node. This is because the node stays in the clipboard after pasting. This PR clears the clipboard after a paste. It solves the issue in the ticket, but it also means you **can't paste a node more than once** (you would have to cut/copy again to paste that node again).

I'm not sure if that's acceptable, so let me know if not and I'll figure out a different fix @taramk 