### PR TITLE
lib: support spaces in field key search

### DIFF
--- a/lib/workbench/workbench.ts
+++ b/lib/workbench/workbench.ts
@@ -344,7 +344,8 @@ export class Workbench {
           fields[f.name.toLowerCase()] = f.value.toLowerCase();
         }
         for (const f in fieldQuery) {
-          if (!fields[f] || fields[f] !== fieldQuery[f].replace(/['"]/g, "")) {
+          const field = fields[f.replace(/['"]/g, "")];
+          if (!field || field !== fieldQuery[f].replace(/['"]/g, "")) {
             return false;
           }
         }


### PR DESCRIPTION
Closes #277 

Honestly, I don't fully understand this issue. The way the code was written, it should already support both field keys and values containing spaces. But during testing, I noticed something weird. The example Smart Node I made for testing used the following search:

`"travel by":car`

According to a console log, `fieldQuery` contained the object: `{"travel by": "car"}`

During the `for (const f in fieldQuery)` loop, `f` is a string that contained escaped quotes. (example: `"\"travel by\""`). The keys in `fields` didn't. I'm not sure why that's happening, but this change fixes it.

I'll put this out for review, but I'll continue investigating to better understand what's going on.