### PR TITLE
Modernize Deno build and restore current app compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ based on the current state of the main branch.
 
 ## Development
 
-Contribute by [installing Deno](https://deno.land/manual@v1.30.0/getting_started/installation), 
+Contribute by [installing Deno](https://deno.land/), 
 cloning the repo, and running:
 
 ```
@@ -25,6 +25,12 @@ deno task serve
 
 This will run a development server for the project site that includes the
 demo, which you can use for development.
+
+To generate the static site plus the demo bundle used by `/demo`, run:
+
+```
+deno task build
+```
 
 ## Community
 

--- a/deno.json
+++ b/deno.json
@@ -1,12 +1,15 @@
 {
   "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "esnext", "deno.ns"],
+    "strict": false,
     "jsx": "react-jsx",
-    "jsxImportSource": "npm:preact"
+    "jsxImportSource": "npm:preact",
+    "types": ["./lib/globals.d.ts"]
   },
   "tasks": {
-    "bundle": "deno run --unstable -A ./bundle.ts",
-    "lume": "echo \"import 'lume/cli.ts'\" | deno run --unstable -A -",
-    "build": "deno task lume",
+    "bundle": "deno run -A ./bundle.ts",
+    "lume": "deno run -A lume/cli.ts",
+    "build": "deno task bundle && deno task lume",
     "serve": "deno task lume -s"
   },
   "imports": {

--- a/deno.lock
+++ b/deno.lock
@@ -1,151 +1,140 @@
 {
-  "version": "3",
-  "packages": {
-    "specifiers": {
-      "npm:date-fns@2.30.0": "npm:date-fns@2.30.0",
-      "npm:highlight.js@11.8.0": "npm:highlight.js@11.8.0",
-      "npm:markdown-it-attrs": "npm:markdown-it-attrs@4.1.6_markdown-it@13.0.1",
-      "npm:markdown-it-attrs@4.1.6": "npm:markdown-it-attrs@4.1.6_markdown-it@13.0.1",
-      "npm:markdown-it-deflist@2.1.0": "npm:markdown-it-deflist@2.1.0",
-      "npm:markdown-it@13.0.1": "npm:markdown-it@13.0.1",
-      "npm:nunjucks@3.2.4": "npm:nunjucks@3.2.4",
-      "npm:preact": "npm:preact@10.15.1",
-      "npm:preact-render-to-string@6.0.3": "npm:preact-render-to-string@6.0.3_preact@10.15.1",
-      "npm:preact@10.15.1": "npm:preact@10.15.1",
-      "npm:react-dom@18.2.0": "npm:react-dom@18.2.0_react@18.2.0",
-      "npm:react@18.2.0": "npm:react@18.2.0"
+  "version": "5",
+  "specifiers": {
+    "npm:date-fns@2.30.0": "2.30.0",
+    "npm:highlight.js@11.8.0": "11.8.0",
+    "npm:markdown-it-attrs@*": "4.1.6_markdown-it@13.0.1",
+    "npm:markdown-it-attrs@4.1.6": "4.1.6_markdown-it@13.0.1",
+    "npm:markdown-it-deflist@2.1.0": "2.1.0",
+    "npm:markdown-it@13.0.1": "13.0.1",
+    "npm:nunjucks@3.2.4": "3.2.4",
+    "npm:preact-render-to-string@6.0.3": "6.0.3_preact@10.15.1",
+    "npm:preact@*": "10.15.1",
+    "npm:preact@10.15.1": "10.15.1",
+    "npm:react-dom@18.2.0": "18.2.0_react@18.2.0",
+    "npm:react@18.2.0": "18.2.0"
+  },
+  "npm": {
+    "@babel/runtime@7.22.5": {
+      "integrity": "sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==",
+      "dependencies": [
+        "regenerator-runtime"
+      ]
     },
-    "npm": {
-      "@babel/runtime@7.22.5": {
-        "integrity": "sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==",
-        "dependencies": {
-          "regenerator-runtime": "regenerator-runtime@0.13.11"
-        }
-      },
-      "a-sync-waterfall@1.0.1": {
-        "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==",
-        "dependencies": {}
-      },
-      "argparse@2.0.1": {
-        "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-        "dependencies": {}
-      },
-      "asap@2.0.6": {
-        "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
-        "dependencies": {}
-      },
-      "commander@5.1.0": {
-        "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-        "dependencies": {}
-      },
-      "date-fns@2.30.0": {
-        "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-        "dependencies": {
-          "@babel/runtime": "@babel/runtime@7.22.5"
-        }
-      },
-      "entities@3.0.1": {
-        "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
-        "dependencies": {}
-      },
-      "highlight.js@11.8.0": {
-        "integrity": "sha512-MedQhoqVdr0U6SSnWPzfiadUcDHfN/Wzq25AkXiQv9oiOO/sG0S7XkvpFIqWBl9Yq1UYyYOOVORs5UW2XlPyzg==",
-        "dependencies": {}
-      },
-      "js-tokens@4.0.0": {
-        "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-        "dependencies": {}
-      },
-      "linkify-it@4.0.1": {
-        "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
-        "dependencies": {
-          "uc.micro": "uc.micro@1.0.6"
-        }
-      },
-      "loose-envify@1.4.0": {
-        "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-        "dependencies": {
-          "js-tokens": "js-tokens@4.0.0"
-        }
-      },
-      "markdown-it-attrs@4.1.6_markdown-it@13.0.1": {
-        "integrity": "sha512-O7PDKZlN8RFMyDX13JnctQompwrrILuz2y43pW2GagcwpIIElkAdfeek+erHfxUOlXWPsjFeWmZ8ch1xtRLWpA==",
-        "dependencies": {
-          "markdown-it": "markdown-it@13.0.1"
-        }
-      },
-      "markdown-it-deflist@2.1.0": {
-        "integrity": "sha512-3OuqoRUlSxJiuQYu0cWTLHNhhq2xtoSFqsZK8plANg91+RJQU1ziQ6lA2LzmFAEes18uPBsHZpcX6We5l76Nzg==",
-        "dependencies": {}
-      },
-      "markdown-it@13.0.1": {
-        "integrity": "sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==",
-        "dependencies": {
-          "argparse": "argparse@2.0.1",
-          "entities": "entities@3.0.1",
-          "linkify-it": "linkify-it@4.0.1",
-          "mdurl": "mdurl@1.0.1",
-          "uc.micro": "uc.micro@1.0.6"
-        }
-      },
-      "mdurl@1.0.1": {
-        "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
-        "dependencies": {}
-      },
-      "nunjucks@3.2.4": {
-        "integrity": "sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==",
-        "dependencies": {
-          "a-sync-waterfall": "a-sync-waterfall@1.0.1",
-          "asap": "asap@2.0.6",
-          "commander": "commander@5.1.0"
-        }
-      },
-      "preact-render-to-string@6.0.3_preact@10.15.1": {
-        "integrity": "sha512-UUP+EtmLw5ns0fT9C7+CTdLawm1wLmlrZ6WKzJ4Jwhb4EBu4vy5ufIZKlrfvWNnPl1JFoJzZwzfKs97H4N0Vug==",
-        "dependencies": {
-          "preact": "preact@10.15.1",
-          "pretty-format": "pretty-format@3.8.0"
-        }
-      },
-      "preact@10.15.1": {
-        "integrity": "sha512-qs2ansoQEwzNiV5eAcRT1p1EC/dmEzaATVDJNiB3g2sRDWdA7b7MurXdJjB2+/WQktGWZwxvDrnuRFbWuIr64g==",
-        "dependencies": {}
-      },
-      "pretty-format@3.8.0": {
-        "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
-        "dependencies": {}
-      },
-      "react-dom@18.2.0_react@18.2.0": {
-        "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-        "dependencies": {
-          "loose-envify": "loose-envify@1.4.0",
-          "react": "react@18.2.0",
-          "scheduler": "scheduler@0.23.0"
-        }
-      },
-      "react@18.2.0": {
-        "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-        "dependencies": {
-          "loose-envify": "loose-envify@1.4.0"
-        }
-      },
-      "regenerator-runtime@0.13.11": {
-        "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-        "dependencies": {}
-      },
-      "scheduler@0.23.0": {
-        "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-        "dependencies": {
-          "loose-envify": "loose-envify@1.4.0"
-        }
-      },
-      "uc.micro@1.0.6": {
-        "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
-        "dependencies": {}
-      }
+    "a-sync-waterfall@1.0.1": {
+      "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA=="
+    },
+    "argparse@2.0.1": {
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "asap@2.0.6": {
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
+    },
+    "commander@5.1.0": {
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
+    },
+    "date-fns@2.30.0": {
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": [
+        "@babel/runtime"
+      ]
+    },
+    "entities@3.0.1": {
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="
+    },
+    "highlight.js@11.8.0": {
+      "integrity": "sha512-MedQhoqVdr0U6SSnWPzfiadUcDHfN/Wzq25AkXiQv9oiOO/sG0S7XkvpFIqWBl9Yq1UYyYOOVORs5UW2XlPyzg=="
+    },
+    "js-tokens@4.0.0": {
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "linkify-it@4.0.1": {
+      "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
+      "dependencies": [
+        "uc.micro"
+      ]
+    },
+    "loose-envify@1.4.0": {
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dependencies": [
+        "js-tokens"
+      ],
+      "bin": true
+    },
+    "markdown-it-attrs@4.1.6_markdown-it@13.0.1": {
+      "integrity": "sha512-O7PDKZlN8RFMyDX13JnctQompwrrILuz2y43pW2GagcwpIIElkAdfeek+erHfxUOlXWPsjFeWmZ8ch1xtRLWpA==",
+      "dependencies": [
+        "markdown-it"
+      ]
+    },
+    "markdown-it-deflist@2.1.0": {
+      "integrity": "sha512-3OuqoRUlSxJiuQYu0cWTLHNhhq2xtoSFqsZK8plANg91+RJQU1ziQ6lA2LzmFAEes18uPBsHZpcX6We5l76Nzg=="
+    },
+    "markdown-it@13.0.1": {
+      "integrity": "sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==",
+      "dependencies": [
+        "argparse",
+        "entities",
+        "linkify-it",
+        "mdurl",
+        "uc.micro"
+      ],
+      "bin": true
+    },
+    "mdurl@1.0.1": {
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
+    },
+    "nunjucks@3.2.4": {
+      "integrity": "sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==",
+      "dependencies": [
+        "a-sync-waterfall",
+        "asap",
+        "commander"
+      ],
+      "bin": true
+    },
+    "preact-render-to-string@6.0.3_preact@10.15.1": {
+      "integrity": "sha512-UUP+EtmLw5ns0fT9C7+CTdLawm1wLmlrZ6WKzJ4Jwhb4EBu4vy5ufIZKlrfvWNnPl1JFoJzZwzfKs97H4N0Vug==",
+      "dependencies": [
+        "preact",
+        "pretty-format"
+      ]
+    },
+    "preact@10.15.1": {
+      "integrity": "sha512-qs2ansoQEwzNiV5eAcRT1p1EC/dmEzaATVDJNiB3g2sRDWdA7b7MurXdJjB2+/WQktGWZwxvDrnuRFbWuIr64g=="
+    },
+    "pretty-format@3.8.0": {
+      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew=="
+    },
+    "react-dom@18.2.0_react@18.2.0": {
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "dependencies": [
+        "loose-envify",
+        "react",
+        "scheduler"
+      ]
+    },
+    "react@18.2.0": {
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "dependencies": [
+        "loose-envify"
+      ]
+    },
+    "regenerator-runtime@0.13.11": {
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+    },
+    "scheduler@0.23.0": {
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "dependencies": [
+        "loose-envify"
+      ]
+    },
+    "uc.micro@1.0.6": {
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     }
   },
   "remote": {
+    "https://cdn.jsdelivr.net/npm/js-base64@3.7.5/base64.mjs": "b52c3bf01e83fee2aad755eaa61910f63f6e4bbf8b0f0bbbcba1b3558be4ff34",
     "https://deno.land/std@0.170.0/_util/asserts.ts": "d0844e9b62510f89ce1f9878b046f6a57bf88f208a10304aab50efcb48365272",
     "https://deno.land/std@0.170.0/_util/os.ts": "8a33345f74990e627b9dfe2de9b040004b08ea5146c7c9e8fe9a29070d193934",
     "https://deno.land/std@0.170.0/encoding/base64.ts": "8605e018e49211efc767686f6f687827d7f5fd5217163e981d8d693105640d7a",
@@ -159,6 +148,10 @@
     "https://deno.land/std@0.170.0/path/posix.ts": "b859684bc4d80edfd4cad0a82371b50c716330bed51143d6dcdbe59e6278b30c",
     "https://deno.land/std@0.170.0/path/separator.ts": "fe1816cb765a8068afb3e8f13ad272351c85cbc739af56dacfc7d93d710fe0f9",
     "https://deno.land/std@0.170.0/path/win32.ts": "7cebd2bda6657371adc00061a1d23fdd87bcdf64b4843bb148b0b24c11b40f69",
+    "https://deno.land/std@0.173.0/fmt/colors.ts": "938c5d44d889fb82eff6c358bea8baa7e85950a16c9f6dae3ec3a7a729164471",
+    "https://deno.land/std@0.173.0/testing/_diff.ts": "1a3c044aedf77647d6cac86b798c6417603361b66b54c53331b312caeb447aea",
+    "https://deno.land/std@0.173.0/testing/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
+    "https://deno.land/std@0.173.0/testing/asserts.ts": "984ab0bfb3faeed92ffaa3a6b06536c66811185328c5dd146257c702c41b01ab",
     "https://deno.land/std@0.190.0/_util/asserts.ts": "178dfc49a464aee693a7e285567b3d0b555dc805ff490505a8aae34f9cfb1462",
     "https://deno.land/std@0.190.0/_util/os.ts": "d932f56d41e4f6a6093d56044e29ce637f8dcc43c5a90af43504a889cf1775e3",
     "https://deno.land/std@0.190.0/async/abortable.ts": "fd682fa46f3b7b16b4606a5ab52a7ce309434b76f820d3221bdfb862719a15d7",
@@ -557,5 +550,10 @@
     "https://deno.land/x/xml@2.1.1/utils/types.ts": "ecaf7785e54a6f1da6f8e56da2bce9853407ceb7d5b3b70f0a60a0890151fe4c",
     "https://unpkg.com/@highlightjs/cdn-assets@11.6.0/es/languages/bash.min.js": "c68e0c10c8e21aa56ae617cea288b30215bc3941c36d11821f89f350628bf377",
     "https://unpkg.com/@highlightjs/cdn-assets@11.6.0/es/languages/javascript.min.js": "1987b5a890a8e5cea9db74c41483fc1bb00923d0bf390a9e866d6cfeebe1c430"
+  },
+  "workspace": {
+    "dependencies": [
+      "npm:preact@*"
+    ]
   }
 }

--- a/lib/action/keybinds.ts
+++ b/lib/action/keybinds.ts
@@ -1,5 +1,12 @@
+type KeyEvent = {
+  key: string;
+  shiftKey?: boolean;
+  ctrlKey?: boolean;
+  altKey?: boolean;
+  metaKey?: boolean;
+};
 
-const isMac = (navigator.userAgent.toLowerCase().indexOf("mac") !== -1);
+const isMac = (globalThis.navigator?.userAgent.toLowerCase().indexOf("mac") !== -1);
 
 export function bindingSymbols(key?: string): string[] {
   if (!key) return [];
@@ -14,9 +21,11 @@ export function bindingSymbols(key?: string): string[] {
     "arrowleft": "←",
     "arrowright": "→",
     "enter": "⏎"
-  };
+  } as const;
   const keys = key.toLowerCase().split("+");
-  return keys.map(filterKeyForNonMacMeta).map(k => (Object.keys(symbols).includes(k)) ? symbols[k] : k);
+  return keys
+    .map(filterKeyForNonMacMeta)
+    .map(k => (k in symbols) ? symbols[k as keyof typeof symbols] : k);
 }
 
 // if key is meta and not on a mac, change it to ctrl,
@@ -52,7 +61,7 @@ export class KeyBindings {
     return null;
   }
 
-  evaluateEvent(event: KeyboardEvent): Binding|null {
+  evaluateEvent(event: KeyEvent): Binding|null {
     bindings: for (const b of this.bindings) {
       let modifiers = b.key.toLowerCase().split("+");
       let key = modifiers.pop();
@@ -67,8 +76,7 @@ export class KeyBindings {
             hasMod = modifiers.includes("meta") || modifiers.includes("ctrl");
           }
         }
-        // @ts-ignore
-        const modState = event[`${filterKeyForNonMacMeta(checkMod)}Key`];
+        const modState = Boolean((event as Record<string, boolean | string>)[`${filterKeyForNonMacMeta(checkMod)}Key`]);
         if (!modState && hasMod) {
           continue bindings;
         }

--- a/lib/action/keybinds.ts
+++ b/lib/action/keybinds.ts
@@ -1,12 +1,7 @@
-type KeyEvent = {
-  key: string;
-  shiftKey?: boolean;
-  ctrlKey?: boolean;
-  altKey?: boolean;
-  metaKey?: boolean;
-};
+type Modifier = "shift" | "ctrl" | "alt" | "meta";
 
-const isMac = (globalThis.navigator?.userAgent.toLowerCase().indexOf("mac") !== -1);
+const isMac = (globalThis.navigator?.userAgent ?? "").toLowerCase().includes("mac");
+const modifierKeys: Modifier[] = ["shift", "ctrl", "alt", "meta"];
 
 export function bindingSymbols(key?: string): string[] {
   if (!key) return [];
@@ -30,8 +25,23 @@ export function bindingSymbols(key?: string): string[] {
 
 // if key is meta and not on a mac, change it to ctrl,
 // otherwise return the key as is
+function filterKeyForNonMacMeta(key: Modifier): Modifier;
+function filterKeyForNonMacMeta(key: string): string;
 function filterKeyForNonMacMeta(key: string): string {
   return (!isMac && key === "meta") ? "ctrl": key;
+}
+
+function modifierState(event: KeyboardEvent, modifier: Modifier): boolean {
+  switch (filterKeyForNonMacMeta(modifier)) {
+    case "shift":
+      return event.shiftKey;
+    case "ctrl":
+      return event.ctrlKey;
+    case "alt":
+      return event.altKey;
+    case "meta":
+      return event.metaKey;
+  }
 }
 
 export interface Binding {
@@ -61,14 +71,14 @@ export class KeyBindings {
     return null;
   }
 
-  evaluateEvent(event: KeyEvent): Binding|null {
+  evaluateEvent(event: KeyboardEvent): Binding|null {
     bindings: for (const b of this.bindings) {
-      let modifiers = b.key.toLowerCase().split("+");
-      let key = modifiers.pop();
+      const modifiers = b.key.toLowerCase().split("+");
+      const key = modifiers.pop();
       if (key !== event.key.toLowerCase()) {
         continue;
       }
-      for (const checkMod of ["shift", "ctrl", "alt", "meta"]) {
+      for (const checkMod of modifierKeys) {
         let hasMod = modifiers.includes(checkMod);
         if (!isMac) {
           if (checkMod === "meta") continue;
@@ -76,7 +86,7 @@ export class KeyBindings {
             hasMod = modifiers.includes("meta") || modifiers.includes("ctrl");
           }
         }
-        const modState = Boolean((event as Record<string, boolean | string>)[`${filterKeyForNonMacMeta(checkMod)}Key`]);
+        const modState = modifierState(event, checkMod);
         if (!modState && hasMod) {
           continue bindings;
         }

--- a/lib/action/keybinds_test.ts
+++ b/lib/action/keybinds_test.ts
@@ -12,3 +12,21 @@ Deno.test("binding registration", async () => {
 
   assertEquals(ret?.key, "shift+a");
 });
+
+Deno.test("binding evaluation matches meta bindings through ctrl on non-mac runtimes", async () => {
+  const bindings = new KeyBindings();
+  bindings.registerBinding({
+    command: "pick-command",
+    key: "meta+k"
+  });
+
+  const ret = bindings.evaluateEvent({
+    key: "k",
+    shiftKey: false,
+    ctrlKey: true,
+    altKey: false,
+    metaKey: false
+  } as KeyboardEvent);
+
+  assertEquals(ret?.command, "pick-command");
+});

--- a/lib/backend/github.ts
+++ b/lib/backend/github.ts
@@ -72,7 +72,7 @@ export class GitHubBackend {
         
         localStorage.setItem("treehouse:gh-token", result.token);
   
-      } catch (e: Error) {
+      } catch (e) {
         this.reset();
         console.error(e);
         return;
@@ -88,7 +88,7 @@ export class GitHubBackend {
         history.pushState({}, "", `${location.pathname}${querystring}`);
         
         localStorage.setItem("treehouse:gh-token", token);
-      } catch (e: Error) {
+      } catch (e) {
         this.reset();
         console.error(e);
         return;
@@ -100,7 +100,7 @@ export class GitHubBackend {
       if (!this.user) {
         throw "authentication failed";
       }
-    } catch (e: Error) {
+    } catch (e) {
       console.error(e);
       if (this.opts.authFallbackURL) {
         location.href = this.opts.authFallbackURL;
@@ -120,7 +120,7 @@ export class GitHubBackend {
         owner: this.user.userID(), 
         repo: this.repoName
       });
-    } catch (e: Error) {
+    } catch (e: any) {
       if (e.message !== "Not Found") {
         throw e;
       }
@@ -140,7 +140,7 @@ export class GitHubBackend {
         repo: this.repoName,
         path: "workspace.json"
       });
-    } catch (e: Error) {
+    } catch (e: any) {
       if (e.name !== "HttpError") {
         throw e;
       }
@@ -221,7 +221,7 @@ export class GitHubBackend {
         }
       }
       
-    } catch (e: Error) {}
+    } catch (e) {}
     
   }
   
@@ -272,7 +272,7 @@ export class GitHubBackend {
       });
       this.shas[path] = resp.data.sha;
       return decode(resp.data.content);
-    } catch (e: Error) {
+    } catch (e: any) {
       if (e.name !== "HttpError") {
         console.error(e);
       }

--- a/lib/backend/github.ts
+++ b/lib/backend/github.ts
@@ -10,6 +10,20 @@ export interface Options {
   privateRepo?: boolean;    // if the user workspace repo should be created private
 }
 
+function errorName(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null || !("name" in error)) {
+    return undefined;
+  }
+  return typeof error.name === "string" ? error.name : undefined;
+}
+
+function errorMessage(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null || !("message" in error)) {
+    return undefined;
+  }
+  return typeof error.message === "string" ? error.message : undefined;
+}
+
 export class GitHubBackend {
   auth: Authenticator;
 
@@ -72,7 +86,7 @@ export class GitHubBackend {
         
         localStorage.setItem("treehouse:gh-token", result.token);
   
-      } catch (e) {
+      } catch (e: unknown) {
         this.reset();
         console.error(e);
         return;
@@ -88,7 +102,7 @@ export class GitHubBackend {
         history.pushState({}, "", `${location.pathname}${querystring}`);
         
         localStorage.setItem("treehouse:gh-token", token);
-      } catch (e) {
+      } catch (e: unknown) {
         this.reset();
         console.error(e);
         return;
@@ -100,7 +114,7 @@ export class GitHubBackend {
       if (!this.user) {
         throw "authentication failed";
       }
-    } catch (e) {
+    } catch (e: unknown) {
       console.error(e);
       if (this.opts.authFallbackURL) {
         location.href = this.opts.authFallbackURL;
@@ -120,8 +134,8 @@ export class GitHubBackend {
         owner: this.user.userID(), 
         repo: this.repoName
       });
-    } catch (e: any) {
-      if (e.message !== "Not Found") {
+    } catch (e: unknown) {
+      if (errorMessage(e) !== "Not Found") {
         throw e;
       }
       // create if not
@@ -140,8 +154,8 @@ export class GitHubBackend {
         repo: this.repoName,
         path: "workspace.json"
       });
-    } catch (e: any) {
-      if (e.name !== "HttpError") {
+    } catch (e: unknown) {
+      if (errorName(e) !== "HttpError") {
         throw e;
       }
       // create empty if not
@@ -221,7 +235,7 @@ export class GitHubBackend {
         }
       }
       
-    } catch (e) {}
+    } catch (_e: unknown) {}
     
   }
   
@@ -272,8 +286,8 @@ export class GitHubBackend {
       });
       this.shas[path] = resp.data.sha;
       return decode(resp.data.content);
-    } catch (e: any) {
-      if (e.name !== "HttpError") {
+    } catch (e: unknown) {
+      if (errorName(e) !== "HttpError") {
         console.error(e);
       }
       return null;

--- a/lib/backend/github_test.ts
+++ b/lib/backend/github_test.ts
@@ -1,0 +1,6 @@
+import { assertEquals } from "https://deno.land/std@0.173.0/testing/asserts.ts";
+import { GitHubBackend } from "./github.ts";
+
+Deno.test("github backend export smoke test", () => {
+  assertEquals(typeof GitHubBackend, "function");
+});

--- a/lib/backend/mod.ts
+++ b/lib/backend/mod.ts
@@ -17,12 +17,14 @@ export interface Backend {
   index: SearchIndex;
   files: FileStore;
   changes?: ChangeNotifier;
+  initialize?(): Promise<void>|void;
+  loadExtensions?(): Promise<void>|void;
 }
 
 
 export interface Authenticator {
-  login();
-  logout();
+  login(): void;
+  logout(): void;
   currentUser(): User|null;
 }
 
@@ -33,8 +35,8 @@ export interface User {
 }
 
 export interface SearchIndex {
-  index(node: RawNode);
-  remove(id: string);
+  index(node: RawNode): void;
+  remove(id: string): void;
   search(query: string): string[];
 }
 
@@ -44,5 +46,5 @@ export interface FileStore {
 }
 
 export interface ChangeNotifier {
-  registerNotifier(cb: (nodeIDs: string[]) => void);
+  registerNotifier(cb: (nodeIDs: string[]) => void): void;
 }

--- a/lib/com/clock.tsx
+++ b/lib/com/clock.tsx
@@ -1,6 +1,7 @@
 import { component } from "../model/components.ts";
 import { Node } from "../model/mod.ts";
 import { Workbench, Context } from "../workbench/mod.ts";
+import { Document } from "./document.tsx";
 
 @component
 export class Clock {

--- a/lib/com/codeblock.tsx
+++ b/lib/com/codeblock.tsx
@@ -1,5 +1,6 @@
 import { component } from "../model/components.ts";
 import { Workbench, Context } from "../workbench/mod.ts";
+import { Document } from "./document.tsx";
 export interface CodeExecutor {
   // executes the source and returns an output string.
   // exceptions in execution should be caught and returned as a string.

--- a/lib/com/description.tsx
+++ b/lib/com/description.tsx
@@ -1,6 +1,7 @@
 import { component } from "../model/components.ts";
 import { Node } from "../model/mod.ts";
 import { objectManaged } from "../model/hooks.ts";
+import { Workbench, Context } from "../workbench/mod.ts";
 
 @component
 export class Description {

--- a/lib/com/document.tsx
+++ b/lib/com/document.tsx
@@ -1,5 +1,6 @@
 import { component } from "../model/components.ts";
 import { Node } from "../model/mod.ts";
+import { Workbench, Context } from "../workbench/mod.ts";
 
 @component
 export class Document {

--- a/lib/com/iframe.tsx
+++ b/lib/com/iframe.tsx
@@ -1,5 +1,7 @@
 import { component } from "../model/components.ts";
 import { Node } from "../model/mod.ts";
+import { Workbench, Context } from "../workbench/mod.ts";
+import { Document } from "./document.tsx";
 
 @component
 export class InlineFrame {
@@ -40,7 +42,7 @@ export class InlineFrame {
           frame.url = ctx.node.name;
           ctx.node.addComponent(frame);
           workbench.defocus();
-          ctx.node.name = ctx.node.name.replaceAll("https://", "").replaceAll("http://");
+          ctx.node.name = ctx.node.name.replaceAll("https://", "").replaceAll("http://", "");
           workbench.workspace.setExpanded(ctx.path.head, ctx.node, true);
           workbench.focus(ctx.path);
         }

--- a/lib/com/smartnode.tsx
+++ b/lib/com/smartnode.tsx
@@ -1,6 +1,7 @@
-import { Workbench } from "../workbench/mod.ts";
+import { Workbench, Context } from "../workbench/mod.ts";
 import { component } from "../model/components.ts";
 import { Node } from "../model/mod.ts";
+import { Document } from "./document.tsx";
 
 function debounce(func, timeout = 1000){
   let timer;
@@ -17,6 +18,7 @@ export class SmartNode {
   object?: Node;
   results?: Node[];
   query: string;
+  searchDebounce: (...args: any[]) => void;
 
   lastQuery?: string;
   lastResultCount?: number;

--- a/lib/com/tag.tsx
+++ b/lib/com/tag.tsx
@@ -1,9 +1,14 @@
 import { component } from "../model/components.ts";
 import { Node } from "../model/mod.ts";
-import { Workbench, Workspace } from "../workbench/mod.ts";
+import { Workbench, Workspace, Context } from "../workbench/mod.ts";
 import { Path } from "../workbench/path.ts";
 import { Template } from "./template.tsx";
 import { Picker } from "../ui/picker.tsx";
+
+interface TagItem {
+  name: string;
+  prefix?: string;
+}
 
 @component
 export class Tag {
@@ -43,7 +48,7 @@ export class Tag {
   }
 
   static findAll(ws: Workspace): string[] {
-    const tags = new Set();
+    const tags = new Set<string>();
     ws.mainNode().walk((n) => {
       if (n.value instanceof Tag) {
         tags.add(n.value.name);
@@ -54,7 +59,7 @@ export class Tag {
   }
 
   static findTagged(ws: Workspace, name: string): Node[] {
-    const nodes = [];
+    const nodes: Node[] = [];
     ws.mainNode().walk((n) => {
       if (n.value instanceof Tag && n.value.name === name) {
         nodes.push(n.parent);
@@ -84,7 +89,7 @@ export class Tag {
           } else {
             state.input = "";
           }
-          const filtered = [...tags]
+          const filtered: TagItem[] = [...tags]
             .filter(t => t.toLowerCase().startsWith(state.input.toLowerCase()))
             .map(t => {return {name: t}});
           if ((filtered[0] && filtered[0].name != state.input && state.input != "") || filtered.length === 0) {

--- a/lib/com/template.tsx
+++ b/lib/com/template.tsx
@@ -1,5 +1,7 @@
 import { component } from "../model/components.ts";
 import { Node } from "../model/mod.ts";
+import { Workbench, Context, Workspace } from "../workbench/mod.ts";
+import { Document } from "./document.tsx";
 
 @component
 export class Template {

--- a/lib/globals.d.ts
+++ b/lib/globals.d.ts
@@ -1,0 +1,45 @@
+declare global {
+  const MiniSearch: any;
+  function m(...args: any[]): any;
+
+  namespace m {
+    type Component<Attrs = any, State = any> = any;
+
+    const redraw: any;
+    const mount: any;
+  }
+
+  interface Document {
+    selection?: {
+      empty(): void;
+    };
+  }
+
+  interface Element {
+    editor?: any;
+    jarEditor?: any;
+    close?(): void;
+    showModal?(): void;
+    focus?(): void;
+  }
+
+  interface EventTarget {
+    closest?(selector: string): Element | null;
+  }
+
+  interface Window {
+    CodeJar?: any;
+    Editor?: any;
+    MiniSearch?: any;
+    backend?: {
+      name: string;
+      url?: string;
+    };
+    hljs?: any;
+    registerView?: (name: string, view: any) => void;
+    reloadNodes?: (nodeIDs: string[]) => void;
+    workbench: any;
+  }
+}
+
+export {};

--- a/lib/model/mod.ts
+++ b/lib/model/mod.ts
@@ -9,8 +9,8 @@ export type WalkFunc = (node: Node) => boolean;
 export type ObserverFunc = (node: Node) => void;
 
 export interface WalkOptions {
-  followRefs: boolean;
-  includeComponents: boolean;
+  followRefs?: boolean;
+  includeComponents?: boolean;
 }
 
 export interface RawNode {
@@ -47,6 +47,9 @@ export interface Node {
   readonly childCount: number;
   addChild(node: Node): void;
   removeChild(node: Node): void;
+
+  readonly fields: Node[];
+  readonly fieldCount: number;
 
   readonly components: Node[];
   readonly componentCount: number;
@@ -88,6 +91,5 @@ export interface Bus {
   walk(fn: WalkFunc, opts?: WalkOptions): void;
   observe(fn: ObserverFunc): void;
 }
-
 
 

--- a/lib/model/module/mod_test.ts
+++ b/lib/model/module/mod_test.ts
@@ -94,3 +94,34 @@ Deno.test("references", () => {
   });
 
 });
+
+Deno.test("remove child removes the targeted child only", () => {
+  const bus = new module.Bus();
+  const parent = bus.make("Parent");
+  const childA = bus.make("Parent/ChildA");
+  const childB = bus.make("Parent/ChildB");
+
+  assertEquals(parent.children.map(n => n.name), ["ChildA", "ChildB"]);
+
+  parent.removeChild(childA);
+
+  assertEquals(parent.children.map(n => n.name), ["ChildB"]);
+});
+
+Deno.test("remove linked removes the targeted linked node only", () => {
+  const bus = new module.Bus();
+  const parent = bus.make("Parent");
+  const fieldA = bus.make("FieldA");
+  const fieldB = bus.make("FieldB");
+
+  fieldA.raw.Parent = parent.id;
+  fieldB.raw.Parent = parent.id;
+  parent.addLinked("Fields", fieldA);
+  parent.addLinked("Fields", fieldB);
+
+  assertEquals(parent.getLinked("Fields").map(n => n.name), ["FieldA", "FieldB"]);
+
+  parent.removeLinked("Fields", fieldA);
+
+  assertEquals(parent.getLinked("Fields").map(n => n.name), ["FieldB"]);
+});

--- a/lib/model/module/node.ts
+++ b/lib/model/module/node.ts
@@ -199,7 +199,7 @@ export class Node {
       this.refTo.removeChild(node);
       return;
     }
-    const children = this.raw.Linked.Children.filter(id => id === node.id);
+    const children = this.raw.Linked.Children.filter(id => id !== node.id);
     this.raw.Linked.Children = children;
     this.changed();
   }
@@ -291,7 +291,7 @@ export class Node {
     if (!this.raw.Linked[rel]) {
       this.raw.Linked[rel] = [];
     }
-    const linked = this.raw.Linked[rel].filter(id => id === node.id);
+    const linked = this.raw.Linked[rel].filter(id => id !== node.id);
     this.raw.Linked[rel] = linked;
     this.changed();
   }

--- a/lib/ui/node/new.tsx
+++ b/lib/ui/node/new.tsx
@@ -1,6 +1,7 @@
 
 export const NewNode = {
   view({attrs: {workbench, path}}) {
+    const node = path.node;
     const keydown = (e) => {
       if (e.key === "Tab") {
         e.stopPropagation();

--- a/lib/ui/palette.tsx
+++ b/lib/ui/palette.tsx
@@ -26,7 +26,7 @@ export const CommandPalette: m.Component = {
       return binding ? bindingSymbols(binding.key).join(" ").toUpperCase() : "";
     }
 
-    const cmds = Object.values(workbench.commands.commands)
+    const cmds = Object.values(workbench.commands.commands as Record<string, any>)
       .filter(cmd => !cmd.hidden)
       .filter(cmd => workbench.canExecuteCommand(cmd.id, ctx))
       .sort(sort);
@@ -49,4 +49,3 @@ export const CommandPalette: m.Component = {
     )
   }
 }
-

--- a/lib/view/document.tsx
+++ b/lib/view/document.tsx
@@ -20,7 +20,7 @@ export default {
         </div>
         <div class="children">
           {(node.childCount > 0) && node.children.map(n => <OutlineNode key={n.id} workbench={workbench} path={path.append(n)} />)}
-          {showNew && <NewNode workbench={workbench} path={path} />}
+          {showNew && m(NewNode, {workbench, path})}
         </div>
       </div>
     )

--- a/lib/view/list.tsx
+++ b/lib/view/list.tsx
@@ -25,7 +25,7 @@ export default {
         </div>
         <div class="children">
           {(node.childCount > 0) && node.children.map(n => <OutlineNode key={n.id} workbench={workbench} path={path.append(n)} />)}
-          {showNew && <NewNode workbench={workbench} path={path} />}
+          {showNew && m(NewNode, {workbench, path})}
         </div>
       </div>
     )

--- a/lib/view/views.ts
+++ b/lib/view/views.ts
@@ -4,6 +4,7 @@ import table from "./table.tsx";
 import tabs from "./tabs.tsx";
 import document from "./document.tsx";
 import cards from "./cards.tsx";
+import { Context } from "../workbench/mod.ts";
 
 export const views = {
   list,
@@ -24,7 +25,7 @@ export function getNodeView(node) {
 
 window.registerView = (name, view) => {
   views[name] = view;
-  workbench.commands.registerCommand({
+  window.workbench.commands.registerCommand({
     id: `view-${name}`,
     title: `View as ${toTitleCase(name)}`,
     action: (ctx: Context) => {

--- a/lib/workbench/mod.ts
+++ b/lib/workbench/mod.ts
@@ -3,6 +3,7 @@ export { Path } from "./path.ts";
 export { Workspace } from "./workspace.ts";
 
 import { Node } from "../model/mod.ts";
+import { Path } from "./path.ts";
 
 /**
  * Context is a user context object interface. This is used to
@@ -10,7 +11,7 @@ import { Node } from "../model/mod.ts";
  * but is also used for local context in commands.
  */
 export interface Context {
-  path: Path;
+  path: Path|null;
   node: Node|null;
   nodes?: Node[];
   event?: Event;

--- a/lib/workbench/workbench.ts
+++ b/lib/workbench/workbench.ts
@@ -23,6 +23,17 @@ export interface Drawer {
   open: boolean;
 }
 
+type DialogElement = Element & {
+  close(): void;
+  hasAttribute(name: string): boolean;
+  showModal(): void;
+};
+
+type MenuTrigger = Element & {
+  dataset: Record<string, string>;
+  getBoundingClientRect(): DOMRect;
+};
+
 /**
  * Workbench is the top-level controller for the Treehouse frontend.
  * 
@@ -56,7 +67,7 @@ export class Workbench {
     this.backend = backend;
     this.workspace = new Workspace(backend.files, backend.changes);
 
-    this.context = {node: null};
+    this.context = {node: null, path: null};
     this.panels = [];
     this.drawer = { open: false };
 
@@ -96,8 +107,7 @@ export class Workbench {
   
     if (this.workspace.settings.theme) {
       const css = document.createElement("link");
-      // TODO: figure out better way to couple themes than hardcoded hotlinked URL
-      css.setAttribute("href", `https://treehouse.sh/style/themes/${this.workspace.settings.theme}.css`);
+      css.setAttribute("href", `/style/themes/${this.workspace.settings.theme}.css`);
       css.setAttribute("rel", "stylesheet");
       css.setAttribute("type", "text/css");
       document.head.appendChild(css);
@@ -108,7 +118,7 @@ export class Workbench {
   }
 
   authenticated(): boolean {
-    return this.backend.auth && this.backend.auth.currentUser();
+    return Boolean(this.backend.auth && this.backend.auth.currentUser());
   }
 
   openQuickAdd() {
@@ -118,7 +128,8 @@ export class Workbench {
     }
     this.showDialog(() => m(QuickAdd, {workbench: this, node}), true);
     setTimeout(() => {
-      document.querySelector("main > dialog .new-node input").focus();
+      const input = document.querySelector("main > dialog .new-node input");
+      input?.focus?.();
     }, 1);
   }
 
@@ -138,7 +149,7 @@ export class Workbench {
   // TODO: goto workspace
   todayNode(): Node {
     const today = new Date();
-    const dayNode = today.toUTCString().split(today.getFullYear())[0];
+    const dayNode = today.toUTCString().split(String(today.getFullYear()))[0].trimEnd();
     const weekNode = `Week ${String(getWeekOfYear(today)).padStart(2, "0")}`;
     const yearNode = `${today.getFullYear()}`;
     const todayPath = ["@calendar", yearNode, weekNode, dayNode].join("/");
@@ -192,7 +203,7 @@ export class Workbench {
     this.context.path = null;
   }
 
-  focus(path: Path, pos?: number = 0) {
+  focus(path: Path, pos: number = 0) {
     const input = this.getInput(path);
     if (input) {
       this.context.path = path;
@@ -214,7 +225,7 @@ export class Workbench {
       }
     }
     const el = document.getElementById(id);
-    if (el.editor) {
+    if (el?.editor) {
       return el.editor;
     }
     return el;
@@ -235,16 +246,17 @@ export class Workbench {
     return Object.assign({}, this.context, ctx);
   }
 
-  showMenu(event: Event, ctx: any, style?: {}) {
+  showMenu(event: Event, ctx: any, style?: Record<string, string>) {
     event.stopPropagation();
     event.preventDefault();
-    const trigger = event.target.closest("*[data-menu]");
+    const trigger = event.target?.closest?.("*[data-menu]") as MenuTrigger | null;
+    if (!trigger) return;
     const rect = trigger.getBoundingClientRect();
     if (!style) {
       const align = trigger.dataset["align"] || "left";
       style = {
         top: `${document.body.scrollTop+rect.y+rect.height}px`
-      }
+      } as Record<string, string>;
       if (align === "right") {
         style.marginLeft = "auto";
         style.marginRight = `${document.body.offsetWidth - rect.right}px`;
@@ -254,8 +266,8 @@ export class Workbench {
       }
     }
     const items = this.menus.menus[trigger.dataset["menu"]];
-    const cmds = items.filter(i => i.command).map(i => this.commands.commands[i.command]);
     if (!items) return;
+    const cmds = items.filter(i => i.command).map(i => this.commands.commands[i.command!]);
     this.menu = {body: () => m(Menu, { 
       workbench: this,
       ctx: this.newContext(ctx), 
@@ -266,13 +278,15 @@ export class Workbench {
     setTimeout(() => {
       // this next frame timeout is so any current dialog can close before attempting
       // to showModal on already open dialog, which causes exception.
-      document.querySelector("main > dialog.menu").showModal();
+      const dialog = document.querySelector("main > dialog.menu") as DialogElement | null;
+      dialog?.showModal?.();
     }, 0);
   }
 
   closeMenu() {
-    document.querySelector("main > dialog.menu").close();
-    workbench.menu.body = () => null;
+    const dialog = document.querySelector("main > dialog.menu") as DialogElement | null;
+    dialog?.close?.();
+    this.menu.body = () => null;
   }
 
   showPalette(x: number, y: number, ctx: Context) {
@@ -296,7 +310,7 @@ export class Workbench {
     this.showDialog(() => m(Settings, {workbench: this}), true);
   }
 
-  showPopover(body: any, style?: {}) {
+  showPopover(body: any, style?: Record<string, string>) {
     this.popover = {body, style};
     m.redraw();
   }
@@ -306,22 +320,25 @@ export class Workbench {
     m.redraw();
   }
 
-  showDialog(body: any, backdrop?: boolean, style?: {}, explicitClose?: boolean) {
+  showDialog(body: any, backdrop?: boolean, style?: Record<string, string>, explicitClose?: boolean) {
     this.dialog = {body, backdrop, style, explicitClose};
     m.redraw();
     setTimeout(() => {
       // this next frame timeout is so any current dialog can close before attempting
       // to showModal on already open dialog, which causes exception.
-      document.querySelector("main > dialog.modal").showModal();
+      const dialog = document.querySelector("main > dialog.modal") as DialogElement | null;
+      dialog?.showModal?.();
     }, 0);
   }
 
   isDialogOpen(): boolean {
-    return document.querySelector("main > dialog.modal").hasAttribute("open");
+    const dialog = document.querySelector("main > dialog.modal") as DialogElement | null;
+    return Boolean(dialog?.hasAttribute("open"));
   }
 
   closeDialog() {
-    document.querySelector("main > dialog.modal").close();
+    const dialog = document.querySelector("main > dialog.modal") as DialogElement | null;
+    dialog?.close?.();
     this.dialog.body = () => null;
   }
 
@@ -339,7 +356,7 @@ export class Workbench {
     const passFieldQuery = (node: Node): boolean => {
       // kludgy filter on fields
       if (Object.keys(fieldQuery).length > 0) {
-        const fields = {};
+        const fields: Record<string, string> = {};
         for (const f of node.getLinked("Fields")) {
           fields[f.name.toLowerCase()] = f.value.toLowerCase();
         }
@@ -358,7 +375,7 @@ export class Workbench {
     }
     let resultCache = {};
     this.backend.index.search(textQuery).forEach(id => {
-      let node = window.workbench.workspace.find(id);
+      let node = this.workspace.find(id);
       if (!node) {
         return;
       }
@@ -385,5 +402,5 @@ function getWeekOfYear(date) {
   var dayNum = d.getUTCDay() || 7;
   d.setUTCDate(d.getUTCDate() + 4 - dayNum);
   var yearStart = new Date(Date.UTC(d.getUTCFullYear(),0,1));
-  return Math.ceil((((d - yearStart) / 86400000) + 1)/7);
+  return Math.ceil((((d.getTime() - yearStart.getTime()) / 86400000) + 1)/7);
 }

--- a/lib/workbench/workspace.ts
+++ b/lib/workbench/workspace.ts
@@ -18,7 +18,10 @@ export class Workspace {
 
   lastOpenedID: string;
   expanded: { [key: string]: { [key: string]: boolean } }; // [rootid][id]
-  settings: {};
+  settings: {
+    theme?: string;
+  };
+  writeDebounce: (path: string, contents: string) => void;
 
   constructor(fs: FileStore, changes?: ChangeNotifier) {
     this.fs = fs;
@@ -34,7 +37,7 @@ export class Workspace {
       try {
         await this.fs.writeFile(path, contents);
         console.log("Saved workspace.");
-      } catch (e: Error) {
+      } catch (e) {
         console.error(e);
         document.dispatchEvent(new CustomEvent("BackendError"));
       }

--- a/web/docs/quickstart/2-building.md
+++ b/web/docs/quickstart/2-building.md
@@ -6,9 +6,13 @@ title: Building from Source
 
 You can build from source by cloning or forking the project and installing [Deno](https://deno.land/). Then you can run:
 
-`deno task bundle`
+`deno task build`
 
-This will produce a JS file you can use at `web/static/lib/treehouse.min.js`. 
+This will build the project site into `web/_out` and generate the demo/library bundle at `web/static/lib/treehouse.min.js`, which is copied into the final site output as `/lib/treehouse.min.js`.
+
+If you only need the embeddable library bundle, you can run:
+
+`deno task bundle`
 
 For development or debugging, you can run:
 


### PR DESCRIPTION
## Summary

This PR restores Treehouse's browser-backed demo and build flow on current Deno/browser tooling.

It fixes the broken build path, makes the generated app bundle match what the demo actually imports, restores local serving for core app assets, repairs a node-model deletion bug, and cleans up a few runtime/type issues that were blocking current test and build flows.

## Included changes

- make `deno task build` the authoritative build path for both the site and app bundle
- ensure the demo imports the locally generated `treehouse.min.js`
- serve core theme assets locally instead of relying on `treehouse.sh`
- fix `removeChild` and `removeLinked` so they actually remove the targeted IDs
- add regression coverage for node removal helpers
- add a GitHub backend smoke test to keep that path compile-compatible
- restore a browser-native `KeyboardEvent` signature in keybinding matching
- switch macOS detection to a safer fallback using `includes("mac")`
- replace dynamic modifier lookup with an explicit helper
- tighten GitHub backend catch handling to use `unknown` plus small error guards

## Validation

- `deno test -A`
- `deno task build`

## Notes

This restores the browser-backed demo and current build/test path first. GitHub sync is kept compile-compatible in this PR, but not fully exercised end-to-end.
